### PR TITLE
Problem: Chainlink CCIP not integrated as bridge

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -156,6 +156,8 @@ jobs:
 
       - name: Install Foundry (Anvil)
         uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: v1.5.0
 
       - name: Run fork transaction execution tests
         env:

--- a/pydefi/abi/bridge.py
+++ b/pydefi/abi/bridge.py
@@ -171,3 +171,55 @@ ACROSS_SPOKE_POOL = Contract.from_abi(
         "function getCurrentTime() external view returns (uint256)",
     ]
 )
+
+# ---------------------------------------------------------------------------
+# Chainlink CCIP — ABI struct definitions
+# ---------------------------------------------------------------------------
+
+
+class CCIPEVMTokenAmount(ABIStruct):
+    """``Client.EVMTokenAmount`` — one (token, amount) entry in ``EVM2AnyMessage``."""
+
+    token: Annotated[str, "address"]
+    amount: Annotated[int, "uint256"]
+
+
+class CCIPEVM2AnyMessage(ABIStruct):
+    """``Client.EVM2AnyMessage`` — payload to ``IRouterClient.ccipSend`` / ``getFee``.
+
+    Fields:
+        receiver: ``abi.encode(<destination address>)`` — for EVM destinations
+            this is a 32-byte word containing the address right-aligned.
+        data: Arbitrary destination payload (empty for plain token transfers;
+            DeFiVM bytecode for compose flows).
+        tokenAmounts: List of tokens and amounts to transfer.  Each entry's
+            token must be approved to the Router by the sender.
+        feeToken: ERC-20 fee token, or ``address(0)`` to pay the message fee
+            in native gas via ``msg.value``.
+        extraArgs: Tag-prefixed extra arguments.  For v2 lanes this is
+            ``EVM_EXTRA_ARGS_V2_TAG (0x181dcf10)`` followed by
+            ``abi.encode(uint256 gasLimit, bool allowOutOfOrderExecution)``.
+            Empty falls back to the lane default.
+    """
+
+    receiver: Annotated[bytes, "bytes"]
+    data: Annotated[bytes, "bytes"]
+    tokenAmounts: list[CCIPEVMTokenAmount]
+    feeToken: Annotated[str, "address"]
+    extraArgs: Annotated[bytes, "bytes"]
+
+
+# ---------------------------------------------------------------------------
+# Chainlink CCIP — Router contract
+# ---------------------------------------------------------------------------
+
+CCIP_ROUTER = Contract.from_abi(
+    CCIPEVMTokenAmount.human_readable_abi()
+    + CCIPEVM2AnyMessage.human_readable_abi()
+    + [
+        # getFee(destChainSelector, message) -> uint256 fee
+        "function getFee(uint64 destinationChainSelector, CCIPEVM2AnyMessage message) external view returns (uint256 fee)",
+        # ccipSend(destChainSelector, message) payable -> bytes32 messageId
+        "function ccipSend(uint64 destinationChainSelector, CCIPEVM2AnyMessage message) external payable returns (bytes32)",
+    ]
+)

--- a/pydefi/bridge/CCIPComposer.sol
+++ b/pydefi/bridge/CCIPComposer.sol
@@ -8,10 +8,18 @@ pragma solidity ^0.8.24;
  *         bridged tokens.
  *
  * Flow: the Router calls ccipReceive(Any2EVMMessage) → this contract prepends
- * two PUSH_U256 instructions for (amountReceived, sourceChainSelector),
- * transfers the received token to DeFiVM, and forwards the combined program
- * with msg.value attached.  Compose flows expect exactly one entry in
- * destTokenAmounts; multi-token programs should subclass this receiver.
+ * a two-PUSH DeFiVM prologue, transfers the received token to DeFiVM, and
+ * forwards the combined program with msg.value attached.  Compose flows
+ * expect exactly one entry in destTokenAmounts; multi-token programs should
+ * subclass this receiver.
+ *
+ * Stack after prologue (bottom → top):
+ *     stack[0] = amountReceived       (tokens delivered to the composer)
+ *     stack[1] = sourceChainSelector  (CCIP selector of the source chain)
+ *
+ * A typical program therefore begins:
+ *     STORE_REG 0   ; R0 = sourceChainSelector  (pops the top of stack)
+ *     STORE_REG 1   ; R1 = amountReceived
  *
  * Source-side authorisation is opt-in via the (sourceChainSelector,
  * senderHash) allowlist; when allowlistEnabled is false any Router-delivered
@@ -149,7 +157,8 @@ contract CCIPComposer {
         uint256 amountReceived = tokenAmount.amount;
         uint64 sourceSelector = message.sourceChainSelector;
 
-        // Initial DeFiVM stack: [amountReceived, sourceChainSelector] (top).
+        // Stack after prologue, bottom → top: [amountReceived, sourceChainSelector].
+        // First STORE_REG pops sourceChainSelector (top); second pops amountReceived.
         bytes memory program = bytes.concat(
             abi.encodePacked(
                 OP_PUSH_U256, bytes32(amountReceived),

--- a/pydefi/bridge/CCIPComposer.sol
+++ b/pydefi/bridge/CCIPComposer.sol
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+/**
+ * @title CCIPComposer
+ * @notice Destination-chain CCIP receiver that executes a DeFiVM program
+ *         attached to the inbound message after the Router delivers the
+ *         bridged tokens.
+ *
+ * Flow: the Router calls ccipReceive(Any2EVMMessage) → this contract prepends
+ * two PUSH_U256 instructions for (amountReceived, sourceChainSelector),
+ * transfers the received token to DeFiVM, and forwards the combined program
+ * with msg.value attached.  Compose flows expect exactly one entry in
+ * destTokenAmounts; multi-token programs should subclass this receiver.
+ *
+ * Source-side authorisation is opt-in via the (sourceChainSelector,
+ * senderHash) allowlist; when allowlistEnabled is false any Router-delivered
+ * sender may trigger compose (matches OFTComposer).  Set it true and register
+ * trusted senders before deploying any contract that forwards real value.
+ * The compose payload is raw DeFiVM bytecode — simulate before broadcasting.
+ * The owner can recover stuck funds via rescueETH / rescueToken.
+ */
+
+// CCIP types delivered by the Router.
+struct EVMTokenAmount {
+    address token;
+    uint256 amount;
+}
+
+struct Any2EVMMessage {
+    bytes32 messageId;
+    uint64 sourceChainSelector;
+    bytes sender;
+    bytes data;                          // DeFiVM bytecode
+    EVMTokenAmount[] destTokenAmounts;   // minted to address(this)
+}
+
+interface IDeFiVM {
+    function execute(bytes calldata program) external payable;
+}
+
+contract CCIPComposer {
+    // EVM PUSH32 opcode: 1-byte op + 32-byte immediate.
+    uint8 private constant OP_PUSH_U256 = 0x7F;
+
+    error UnauthorizedRouter(address caller);
+    error UnexpectedTokenCount(uint256 count);
+    error UnauthorizedSender(uint64 sourceChainSelector, bytes32 senderHash);
+    error ZeroAddress();
+
+    event Composed(
+        uint64 indexed sourceChainSelector,
+        bytes32 indexed messageId,
+        address token,
+        uint256 amountReceived
+    );
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+    event AllowlistEnabledChanged(bool enabled);
+    event AllowedSenderChanged(uint64 indexed sourceChainSelector, bytes32 indexed senderHash, bool allowed);
+
+    /// @notice CCIP Router authorised to call ccipReceive.
+    address public immutable router;
+    /// @notice DeFiVM contract that executes compose programs.
+    IDeFiVM public immutable vm;
+    /// @notice Owner — may rescue funds, toggle the allowlist, and transfer ownership.
+    address public owner;
+    /// @notice Whether ccipReceive consults `allowedSender`.
+    bool public allowlistEnabled;
+    /// @notice Allowlist keyed by `keccak256(message.sender)` because CCIP
+    ///         delivers the source address as variable-length `bytes`.
+    mapping(uint64 sourceChainSelector => mapping(bytes32 senderHash => bool)) public allowedSender;
+
+    /**
+     * @param _allowlistEnabled  Pass `true` for production deployments that
+     *        forward real value — they start fail-closed and require the
+     *        owner to register trusted (selector, sender) pairs via
+     *        `setAllowed`.  Pass `false` for tests / dev.
+     * @dev   All address arguments must be non-zero.
+     */
+    constructor(address _router, address _vm, address _owner, bool _allowlistEnabled) {
+        if (_router == address(0)) revert ZeroAddress();
+        if (_vm == address(0)) revert ZeroAddress();
+        if (_owner == address(0)) revert ZeroAddress();
+        router = _router;
+        vm = IDeFiVM(_vm);
+        owner = _owner;
+        allowlistEnabled = _allowlistEnabled;
+        emit AllowlistEnabledChanged(_allowlistEnabled);
+    }
+
+    modifier onlyOwner() {
+        require(msg.sender == owner, "CCIPComposer: not owner");
+        _;
+    }
+
+    function transferOwnership(address _newOwner) external onlyOwner {
+        require(_newOwner != address(0), "CCIPComposer: zero address");
+        emit OwnershipTransferred(owner, _newOwner);
+        owner = _newOwner;
+    }
+
+    function rescueETH(address payable _recipient, uint256 _amount) external onlyOwner {
+        require(_recipient != address(0), "CCIPComposer: zero address");
+        (bool ok, ) = _recipient.call{value: _amount}("");
+        require(ok, "CCIPComposer: ETH transfer failed");
+    }
+
+    function rescueToken(address _token, address _recipient, uint256 _amount) external onlyOwner {
+        require(_recipient != address(0), "CCIPComposer: zero address");
+        (bool ok, bytes memory ret) = _token.call(
+            abi.encodeWithSignature("transfer(address,uint256)", _recipient, _amount)
+        );
+        require(ok && (ret.length == 0 || abi.decode(ret, (bool))), "CCIPComposer: token transfer failed");
+    }
+
+    function setAllowlistEnabled(bool _enabled) external onlyOwner {
+        allowlistEnabled = _enabled;
+        emit AllowlistEnabledChanged(_enabled);
+    }
+
+    /// @param _sender Raw `message.sender` bytes; EVM senders are `abi.encode(address)`.
+    function setAllowed(
+        uint64 _sourceChainSelector,
+        bytes calldata _sender,
+        bool _allowed
+    ) external onlyOwner {
+        bytes32 senderHash = keccak256(_sender);
+        allowedSender[_sourceChainSelector][senderHash] = _allowed;
+        emit AllowedSenderChanged(_sourceChainSelector, senderHash, _allowed);
+    }
+
+    /// @notice Authenticate the Router, prepend the DeFiVM prologue, hand the
+    ///         token to DeFiVM, and execute the program.
+    function ccipReceive(Any2EVMMessage calldata message) external payable {
+        if (msg.sender != router) revert UnauthorizedRouter(msg.sender);
+
+        if (allowlistEnabled) {
+            bytes32 senderHash = keccak256(message.sender);
+            if (!allowedSender[message.sourceChainSelector][senderHash]) {
+                revert UnauthorizedSender(message.sourceChainSelector, senderHash);
+            }
+        }
+
+        if (message.destTokenAmounts.length != 1) {
+            revert UnexpectedTokenCount(message.destTokenAmounts.length);
+        }
+
+        EVMTokenAmount calldata tokenAmount = message.destTokenAmounts[0];
+        uint256 amountReceived = tokenAmount.amount;
+        uint64 sourceSelector = message.sourceChainSelector;
+
+        // Initial DeFiVM stack: [amountReceived, sourceChainSelector] (top).
+        bytes memory program = bytes.concat(
+            abi.encodePacked(
+                OP_PUSH_U256, bytes32(amountReceived),
+                OP_PUSH_U256, bytes32(uint256(sourceSelector))
+            ),
+            message.data
+        );
+
+        if (amountReceived > 0) {
+            (bool ok, bytes memory ret) = tokenAmount.token.call(
+                abi.encodeWithSignature("transfer(address,uint256)", address(vm), amountReceived)
+            );
+            require(ok && (ret.length == 0 || abi.decode(ret, (bool))), "CCIPComposer: token transfer failed");
+        }
+
+        vm.execute{value: msg.value}(program);
+        emit Composed(sourceSelector, message.messageId, tokenAmount.token, amountReceived);
+    }
+
+    receive() external payable {}
+}

--- a/pydefi/bridge/__init__.py
+++ b/pydefi/bridge/__init__.py
@@ -2,6 +2,7 @@
 
 from pydefi.bridge.across import Across
 from pydefi.bridge.base import BaseBridge
+from pydefi.bridge.ccip import CCIP, EVM_EXTRA_ARGS_V2_TAG
 from pydefi.bridge.cctp import (
     CCTP,
     FINALITY_THRESHOLD_CONFIRMED,
@@ -14,10 +15,13 @@ from pydefi.bridge.gaszip import GasZip
 from pydefi.bridge.layerzero_oft import LayerZeroOFT
 from pydefi.bridge.mayan import Mayan
 from pydefi.bridge.relay import Relay
+from pydefi.bridge.router import BridgeRouter, RankedBridgeQuote, rank_bridge_quotes
 from pydefi.bridge.stargate import Stargate
 
 __all__ = [
     "BaseBridge",
+    "BridgeRouter",
+    "RankedBridgeQuote",
     "Stargate",
     "Across",
     "Mayan",
@@ -25,9 +29,12 @@ __all__ = [
     "Relay",
     "LayerZeroOFT",
     "CCTP",
+    "CCIP",
+    "EVM_EXTRA_ARGS_V2_TAG",
     "FINALITY_THRESHOLD_CONFIRMED",
     "FINALITY_THRESHOLD_FINALIZED",
     "HYPERCORE_DEX_PERP",
     "HYPERCORE_DEX_SPOT",
     "encode_cctp_forward_hook_data",
+    "rank_bridge_quotes",
 ]

--- a/pydefi/bridge/ccip.py
+++ b/pydefi/bridge/ccip.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 from typing import Any
 
 from eth_abi import encode as abi_encode
-from web3 import AsyncWeb3, Web3
+from web3 import AsyncWeb3
 
 from pydefi._utils import address_to_bytes32
 from pydefi.abi.bridge import CCIP_ROUTER, CCIPEVM2AnyMessage, CCIPEVMTokenAmount
@@ -151,11 +151,11 @@ class CCIP(BaseBridge):
             data=data,
             tokenAmounts=[
                 CCIPEVMTokenAmount(
-                    token=Web3.to_checksum_address(bytes(token_in.address)),
+                    token=token_in.address,
                     amount=amount_in.amount,
                 )
             ],
-            feeToken=Web3.to_checksum_address(bytes(self.fee_token)),
+            feeToken=self.fee_token,
             extraArgs=extra_args,
         )
 

--- a/pydefi/bridge/ccip.py
+++ b/pydefi/bridge/ccip.py
@@ -25,10 +25,9 @@ EVM_EXTRA_ARGS_V2_TAG: bytes = bytes.fromhex("181dcf10")
 
 
 # CCIP identifies destination chains by a 64-bit selector, distinct from the
-# EVM chain ID.  This map covers every chain pydefi can target as a
-# destination; the source-chain Router map below is a subset, since pydefi
-# only initiates from chains where a Router is also deployed.
-# https://docs.chain.link/ccip/directory/mainnet
+# EVM chain ID.  Source data:
+# https://github.com/smartcontractkit/documentation/blob/main/src/config/data/ccip/v1_2_0/mainnet/chains.json
+# Rendered: https://docs.chain.link/ccip/directory/mainnet
 _CCIP_CHAIN_SELECTOR: dict[int, int] = {
     1: 5009297550715157269,  # Ethereum
     10: 3734403246176062136,  # Optimism
@@ -38,10 +37,9 @@ _CCIP_CHAIN_SELECTOR: dict[int, int] = {
     42161: 4949039107694359620,  # Arbitrum
     43114: 6433500567565415381,  # Avalanche
     59144: 4627098889531055414,  # Linea
-    81457: 4411394078118774322,  # Blast
     324: 1562403441176082196,  # zkSync Era
-    534352: 13264668187771770619,  # Scroll
-    130: 1923510734129558909,  # Unichain
+    534352: 13204309965629103672,  # Scroll
+    130: 1923510103922296319,  # Unichain
     480: 2049429975587534727,  # World Chain
 }
 
@@ -54,9 +52,11 @@ _CCIP_ROUTER: dict[int, str] = {
     8453: "0x881e3A65B4d4a04dD529061dd0071cf975F58bCD",  # Base
     42161: "0x141fa059441E0ca23ce184B6A78bafD2A517DdE8",  # Arbitrum
     43114: "0xF4c7E640EdA248ef95972845a62bdC74237805dB",  # Avalanche
-    59144: "0xb5e8Cc83af0E1ce05A9c5b2655d50e9CF85753f4",  # Linea
-    324: "0xF12CA89aaaeC02E0F2f0F86620586D08D7C9bf85",  # zkSync Era
-    534352: "0x6b9a4fb612b9d3D5fE69bbF93bD8a13767E96b62",  # Scroll
+    59144: "0x549FEB73F2348F6cD99b9fc8c69252034897f06C",  # Linea
+    324: "0x748Fd769d81F5D94752bf8B0875E9301d0ba71bB",  # zkSync Era
+    534352: "0x9a55E8Cab6564eb7bbd7124238932963B8Af71DC",  # Scroll
+    130: "0x68891f5F96695ECd7dEdBE2289D1b73426ae7864",  # Unichain
+    480: "0x5fd9E4986187c56826A3064954Cfa2Cf250cfA0f",  # World Chain
 }
 
 

--- a/pydefi/bridge/ccip.py
+++ b/pydefi/bridge/ccip.py
@@ -1,0 +1,325 @@
+"""Chainlink CCIP bridge integration.
+
+CCIP transfers tokens and an arbitrary ``data`` payload in one ``ccipSend``
+call.  Tokens are 1:1; the per-message fee is paid separately in native gas
+or an ERC-20 fee token.  See :class:`CCIPComposer` for the compose path.
+
+Docs: https://docs.chain.link/ccip
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from eth_abi import encode as abi_encode
+from web3 import AsyncWeb3, Web3
+
+from pydefi._utils import address_to_bytes32
+from pydefi.abi.bridge import CCIP_ROUTER, CCIPEVM2AnyMessage, CCIPEVMTokenAmount
+from pydefi.bridge.base import BaseBridge
+from pydefi.exceptions import BridgeError
+from pydefi.types import ZERO_ADDRESS, Address, BridgeQuote, Token, TokenAmount
+
+# bytes4(keccak256("CCIP EVMExtraArgsV2")).
+EVM_EXTRA_ARGS_V2_TAG: bytes = bytes.fromhex("181dcf10")
+
+
+# CCIP identifies destination chains by a 64-bit selector, distinct from the
+# EVM chain ID.  This map covers every chain pydefi can target as a
+# destination; the source-chain Router map below is a subset, since pydefi
+# only initiates from chains where a Router is also deployed.
+# https://docs.chain.link/ccip/directory/mainnet
+_CCIP_CHAIN_SELECTOR: dict[int, int] = {
+    1: 5009297550715157269,  # Ethereum
+    10: 3734403246176062136,  # Optimism
+    56: 11344663589394136015,  # BNB Chain
+    137: 4051577828743386545,  # Polygon
+    8453: 15971525489660198786,  # Base
+    42161: 4949039107694359620,  # Arbitrum
+    43114: 6433500567565415381,  # Avalanche
+    59144: 4627098889531055414,  # Linea
+    81457: 4411394078118774322,  # Blast
+    324: 1562403441176082196,  # zkSync Era
+    534352: 13264668187771770619,  # Scroll
+    130: 1923510734129558909,  # Unichain
+    480: 2049429975587534727,  # World Chain
+}
+
+# Canonical mainnet Router deployments.
+_CCIP_ROUTER: dict[int, str] = {
+    1: "0x80226fc0Ee2b096224EeAc085Bb9a8cba1146f7D",  # Ethereum
+    10: "0x3206695CaE29952f4b0c22a169725a865bc8Ce0f",  # Optimism
+    56: "0x34B03Cb9086d7D758AC55af71584F81A598759FE",  # BNB Chain
+    137: "0x849c5ED5a80F5B408Dd4969b78c2C8fdf0565Bfe",  # Polygon
+    8453: "0x881e3A65B4d4a04dD529061dd0071cf975F58bCD",  # Base
+    42161: "0x141fa059441E0ca23ce184B6A78bafD2A517DdE8",  # Arbitrum
+    43114: "0xF4c7E640EdA248ef95972845a62bdC74237805dB",  # Avalanche
+    59144: "0xb5e8Cc83af0E1ce05A9c5b2655d50e9CF85753f4",  # Linea
+    324: "0xF12CA89aaaeC02E0F2f0F86620586D08D7C9bf85",  # zkSync Era
+    534352: "0x6b9a4fb612b9d3D5fE69bbF93bD8a13767E96b62",  # Scroll
+}
+
+
+def _ccip_chain_selector(evm_chain_id: int) -> int:
+    selector = _CCIP_CHAIN_SELECTOR.get(evm_chain_id)
+    if selector is None:
+        raise BridgeError(f"CCIP: unsupported chain {evm_chain_id} (no chain selector known).")
+    return selector
+
+
+# Outbound transaction gas budgets.  CCIP `ccipSend` itself is ~250k baseline;
+# we bump both to absorb large message payloads (especially DeFiVM bytecode in
+# the compose path) and post-EIP-3860 / EOF overhead.
+_DEFAULT_SEND_GAS = 500_000
+_DEFAULT_COMPOSE_GAS = 600_000
+
+
+class CCIP(BaseBridge):
+    """Chainlink CCIP bridge — token-only or compose ``ccipSend`` via the Router.
+
+    Tokens are bridged 1:1; the per-message fee is paid in native gas
+    (``fee_token=None``) or in an ERC-20 fee token such as LINK.  Lane
+    support and token allowlisting are enforced by the Router — unsupported
+    tokens / lanes surface as :class:`~pydefi.exceptions.BridgeError` on the
+    first :meth:`get_quote` (mirrors :class:`~pydefi.bridge.LayerZeroOFT`).
+
+    Args:
+        w3: AsyncWeb3 for the source chain (drives :meth:`Router.getFee`).
+        src_chain_id, dst_chain_id: EVM chain IDs.
+        router_address: Override the source Router address; defaults to the
+            canonical mainnet deployment for ``src_chain_id``.
+        fee_token: ERC-20 fee token address, or ``None`` for native gas.  When
+            set, the caller approves this token to the Router for the fee.
+        fee_token_decimals: Precision of the fee token (default 18 — correct
+            for native gas and LINK; pass 6 for USDC-as-fee on lanes that
+            accept it).  Flows into :attr:`BridgeQuote.bridge_fee` so
+            :class:`~pydefi.bridge.BridgeRouter` can convert the fee.
+        fee_token_symbol: Override the synthetic symbol on the fee Token.
+    """
+
+    def __init__(
+        self,
+        w3: AsyncWeb3,
+        src_chain_id: int,
+        dst_chain_id: int,
+        router_address: str | None = None,
+        fee_token: Address | None = None,
+        fee_token_decimals: int = 18,
+        fee_token_symbol: str | None = None,
+    ) -> None:
+        super().__init__(src_chain_id, dst_chain_id)
+        self.w3 = w3
+
+        self.router_address = router_address or _CCIP_ROUTER.get(src_chain_id, "")
+        if not self.router_address:
+            raise BridgeError(
+                f"CCIP: no Router address known for chain {src_chain_id}. Pass router_address explicitly."
+            )
+
+        self.fee_token: Address = fee_token if fee_token is not None else ZERO_ADDRESS
+        # bool subclasses int — reject explicitly so True/False don't sneak in.
+        if not isinstance(fee_token_decimals, int) or isinstance(fee_token_decimals, bool):
+            raise BridgeError(f"CCIP: fee_token_decimals must be an int, got {type(fee_token_decimals).__name__}")
+        if not 0 <= fee_token_decimals <= 36:
+            raise BridgeError(f"CCIP: fee_token_decimals must be in [0, 36], got {fee_token_decimals}")
+        self.fee_token_decimals: int = fee_token_decimals
+        self.fee_token_symbol: str | None = fee_token_symbol
+
+        # Resolve eagerly so unsupported destinations fail at construction.
+        self.dst_chain_selector = _ccip_chain_selector(dst_chain_id)
+
+    @property
+    def protocol_name(self) -> str:
+        return "CCIP"
+
+    def _build_message(
+        self,
+        recipient: Address,
+        token_in: Token,
+        amount_in: TokenAmount,
+        data: bytes,
+        gas_limit: int,
+        allow_out_of_order_execution: bool,
+    ) -> CCIPEVM2AnyMessage:
+        # ``receiver`` is abi.encode(address) for EVM destinations.
+        # ``extraArgs`` v2 layout: 0x181dcf10 ++ abi.encode(uint256, bool).
+        extra_args = EVM_EXTRA_ARGS_V2_TAG + abi_encode(
+            ["uint256", "bool"], [gas_limit, bool(allow_out_of_order_execution)]
+        )
+        return CCIPEVM2AnyMessage(
+            receiver=bytes(address_to_bytes32(recipient)),
+            data=data,
+            tokenAmounts=[
+                CCIPEVMTokenAmount(
+                    token=Web3.to_checksum_address(bytes(token_in.address)),
+                    amount=amount_in.amount,
+                )
+            ],
+            feeToken=Web3.to_checksum_address(bytes(self.fee_token)),
+            extraArgs=extra_args,
+        )
+
+    async def quote_fee(
+        self,
+        token_in: Token,
+        amount_in: TokenAmount,
+        recipient: Address,
+        data: bytes = b"",
+        gas_limit: int = 0,
+        allow_out_of_order_execution: bool = False,
+    ) -> int:
+        """Call ``Router.getFee`` and return the message fee in :attr:`fee_token`.
+
+        Reverts on unsupported lanes or non-allowlisted tokens.
+        """
+        message = self._build_message(
+            recipient=recipient,
+            token_in=token_in,
+            amount_in=amount_in,
+            data=data,
+            gas_limit=gas_limit,
+            allow_out_of_order_execution=allow_out_of_order_execution,
+        )
+        try:
+            fee = await CCIP_ROUTER.fns.getFee(self.dst_chain_selector, message).call(self.w3, to=self.router_address)
+        except Exception as exc:
+            raise BridgeError(f"CCIP: getFee failed: {exc}") from exc
+        return int(fee)
+
+    # -----------------------------------------------------------------------
+    # BaseBridge interface
+    # -----------------------------------------------------------------------
+
+    async def get_quote(
+        self,
+        token_in: Token,
+        token_out: Token,
+        amount_in: TokenAmount,
+        recipient: Address | None = None,
+        gas_limit: int = 0,
+        allow_out_of_order_execution: bool = False,
+        **kwargs: Any,
+    ) -> BridgeQuote:
+        """Quote a CCIP transfer; bridge_fee is denominated in :attr:`fee_token`.
+
+        ``recipient`` is only used to derive ``getFee`` calldata (the fee is
+        recipient-independent); zero address is used when ``None``.
+        """
+        _recipient = recipient if recipient is not None else ZERO_ADDRESS
+        fee = await self.quote_fee(
+            token_in=token_in,
+            amount_in=amount_in,
+            recipient=_recipient,
+            gas_limit=gas_limit,
+            allow_out_of_order_execution=allow_out_of_order_execution,
+        )
+
+        fee_token_symbol = self.fee_token_symbol or ("NATIVE" if self.fee_token == ZERO_ADDRESS else "FEE")
+        fee_token = Token(
+            chain_id=self.src_chain_id,
+            address=self.fee_token,
+            symbol=fee_token_symbol,
+            decimals=self.fee_token_decimals,
+        )
+
+        return BridgeQuote(
+            token_in=token_in,
+            token_out=token_out,
+            amount_in=amount_in,
+            amount_out=TokenAmount(token=token_out, amount=amount_in.amount),
+            bridge_fee=TokenAmount(token=fee_token, amount=fee),
+            # CCIP's public finality target is ~10 minutes on most lanes.
+            estimated_time_seconds=600,
+            protocol=self.protocol_name,
+        )
+
+    def _encode_send_tx(self, message: CCIPEVM2AnyMessage, fee: int, *, gas_budget: int) -> dict[str, Any]:
+        """Encode a ``ccipSend`` tx dict for *message* with *fee* already known."""
+        call_data = CCIP_ROUTER.fns.ccipSend(self.dst_chain_selector, message).data
+        return {
+            "to": self.router_address,
+            "data": "0x" + call_data.hex(),
+            "value": str(fee if self.fee_token == ZERO_ADDRESS else 0),
+            "gas": str(gas_budget),
+        }
+
+    async def build_bridge_tx(
+        self,
+        token_in: Token,
+        token_out: Token,
+        amount_in: TokenAmount,
+        recipient: Address,
+        slippage_bps: int = 0,
+        data: bytes = b"",
+        gas_limit: int = 0,
+        allow_out_of_order_execution: bool = False,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        """Build a ``ccipSend`` transaction.
+
+        Native fee → ``value = fee``.  ERC-20 fee → ``value = 0`` and the
+        caller must have approved the fee token to the Router.  In both cases
+        the caller must approve ``token_in`` for ``amount_in`` first.
+
+        ``slippage_bps`` is ignored (CCIP is 1:1).  Pass DeFiVM bytecode as
+        ``data`` and raise ``gas_limit`` (~200 000) for compose flows.
+        """
+        del token_out, slippage_bps  # unused — CCIP is 1:1 and has no slippage
+        message = self._build_message(
+            recipient=recipient,
+            token_in=token_in,
+            amount_in=amount_in,
+            data=data,
+            gas_limit=gas_limit,
+            allow_out_of_order_execution=allow_out_of_order_execution,
+        )
+        fee = await self.quote_fee(
+            token_in=token_in,
+            amount_in=amount_in,
+            recipient=recipient,
+            data=data,
+            gas_limit=gas_limit,
+            allow_out_of_order_execution=allow_out_of_order_execution,
+        )
+        return self._encode_send_tx(message, fee, gas_budget=_DEFAULT_SEND_GAS)
+
+    async def build_bridge_compose_tx(
+        self,
+        token_in: Token,
+        amount_in: TokenAmount,
+        composer_address: Address,
+        program: bytes,
+        gas_limit: int = 800_000,
+        allow_out_of_order_execution: bool = False,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        """Build a ``ccipSend`` transaction that triggers a DeFiVM compose.
+
+        Sets the message ``receiver`` to *composer_address* and ``data`` to
+        the raw DeFiVM bytecode.  CCIP delivers the bridged tokens to the
+        composer and invokes ``ccipReceive``; the composer prepends
+        ``(amountReceived, sourceChainSelector)`` and forwards execution to
+        DeFiVM.  Same approval rules as :meth:`build_bridge_tx`.
+
+        ``gas_limit`` defaults to 800 000 — enough for a typical
+        transfer + DEX swap; raise for fan-out programs.
+        """
+        if not program:
+            raise BridgeError("CCIP: program must not be empty for compose transactions.")
+        message = self._build_message(
+            recipient=composer_address,
+            token_in=token_in,
+            amount_in=amount_in,
+            data=program,
+            gas_limit=gas_limit,
+            allow_out_of_order_execution=allow_out_of_order_execution,
+        )
+        fee = await self.quote_fee(
+            token_in=token_in,
+            amount_in=amount_in,
+            recipient=composer_address,
+            data=program,
+            gas_limit=gas_limit,
+            allow_out_of_order_execution=allow_out_of_order_execution,
+        )
+        return self._encode_send_tx(message, fee, gas_budget=_DEFAULT_COMPOSE_GAS)

--- a/pydefi/bridge/router.py
+++ b/pydefi/bridge/router.py
@@ -59,10 +59,15 @@ def rank_bridge_quotes(
     ranked: list[RankedBridgeQuote] = []
     for quote in quotes:
         fee_addr = quote.bridge_fee.token.address
+        amount_in = quote.amount_in.amount
         amount_out = quote.amount_out.amount
+        fee = quote.bridge_fee.amount
 
-        if fee_addr in (quote.token_in.address, quote.token_out.address):
-            # Fee already netted into amount_out by the bridge.
+        # Fast-path: only when the fee is in token_in / token_out *and* the
+        # amount_in / amount_out / fee triple says it's already netted.
+        # Catches CCIP fee-in-token_in (e.g. USDC-as-fee bridging USDC) where
+        # the fee is separate even though the addresses match.
+        if fee_addr in (quote.token_in.address, quote.token_out.address) and amount_out + fee == amount_in:
             ranked.append(RankedBridgeQuote(quote, amount_out, 0, False))
             continue
 

--- a/pydefi/bridge/router.py
+++ b/pydefi/bridge/router.py
@@ -72,8 +72,8 @@ def rank_bridge_quotes(
         else:
             ranked.append(RankedBridgeQuote(quote, amount_out - converted, converted, False))
 
-    # Stable: unranked → last; within each group, higher effective_amount_out first.
-    ranked.sort(key=lambda r: (r.fee_unranked, -r.effective_amount_out))
+    # Ranked first by effective_amount_out (desc), unranked last in insertion order
+    ranked.sort(key=lambda r: (r.fee_unranked, 0 if r.fee_unranked else -r.effective_amount_out))
     return ranked
 
 

--- a/pydefi/bridge/router.py
+++ b/pydefi/bridge/router.py
@@ -1,0 +1,128 @@
+"""Quote a lane across multiple bridges and rank by effective delivered amount.
+
+Legacy bridges (CCTP / Stargate / Across / Mayan / LayerZeroOFT / GasZip /
+Relay) deduct their fee from ``amount_out`` and set ``bridge_fee.token``
+to ``token_in``, so quotes are directly comparable.  CCIP leaves the
+bridged amount intact and charges a separate fee in native gas or LINK;
+ranking it fairly needs a caller-supplied ``FeeConverter`` that prices
+the fee in ``token_out`` sub-units.  Unconvertible quotes are tagged
+``fee_unranked`` and sorted last — never treated as free.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from pydefi.bridge.base import BaseBridge
+from pydefi.exceptions import BridgeError
+from pydefi.types import BridgeQuote, Token, TokenAmount
+
+#: Returns the fee in ``quote.token_out`` sub-units, or ``None`` if unpriced.
+FeeConverter = Callable[[BridgeQuote], "int | None"]
+
+
+@dataclass
+class RankedBridgeQuote:
+    """A :class:`BridgeQuote` paired with its fee-adjusted score.
+
+    ``effective_amount_out`` is ``amount_out`` for quotes whose fee is already
+    netted into the bridged amount; otherwise it's ``amount_out`` minus the
+    converted fee.  ``fee_unranked`` is set when the fee is in a third token
+    and no converter could price it — such quotes sort last.
+    """
+
+    quote: BridgeQuote
+    effective_amount_out: int
+    fee_in_token_out_units: int
+    fee_unranked: bool
+
+    @property
+    def protocol(self) -> str:
+        return self.quote.protocol
+
+
+def rank_bridge_quotes(
+    quotes: Sequence[BridgeQuote],
+    *,
+    fee_converter: FeeConverter | None = None,
+) -> list[RankedBridgeQuote]:
+    """Rank *quotes* by effective amount delivered, best first.
+
+    Quotes whose fee is denominated in a third token and cannot be priced by
+    *fee_converter* are tagged ``fee_unranked`` and sorted last.  The sort is
+    stable: input order is preserved within the rankable and unrankable
+    groups.
+    """
+    ranked: list[RankedBridgeQuote] = []
+    for quote in quotes:
+        fee_addr = quote.bridge_fee.token.address
+        amount_out = quote.amount_out.amount
+
+        if fee_addr in (quote.token_in.address, quote.token_out.address):
+            # Fee already netted into amount_out by the bridge.
+            ranked.append(RankedBridgeQuote(quote, amount_out, 0, False))
+            continue
+
+        converted = fee_converter(quote) if fee_converter is not None else None
+        if converted is None:
+            ranked.append(RankedBridgeQuote(quote, amount_out, 0, True))
+        else:
+            ranked.append(RankedBridgeQuote(quote, amount_out - converted, converted, False))
+
+    # Stable: unranked → last; within each group, higher effective_amount_out first.
+    ranked.sort(key=lambda r: (r.fee_unranked, -r.effective_amount_out))
+    return ranked
+
+
+class BridgeRouter:
+    """Fan ``get_quote`` out to a set of bridges in parallel.
+
+    Bridges that raise :class:`BridgeError` (lane unsupported, token not on
+    allowlist, …) are silently dropped; any other exception propagates.  The
+    returned quotes are typically passed to :func:`rank_bridge_quotes` for
+    fee-aware ranking — see the example below.
+
+    Example::
+
+        router = BridgeRouter([
+            CCTP(w3, src_chain_id=1, dst_chain_id=8453),
+            CCIP(w3, src_chain_id=1, dst_chain_id=8453),
+        ])
+
+        def fee_to_usdc(q):  # CCIP pays in native ETH; price it in token_out.
+            if q.protocol != "CCIP":
+                return None
+            return int(q.bridge_fee.amount * eth_price_in_usdc * 10**q.token_out.decimals // 10**18)
+
+        quotes = await router.quote_all(token_in, token_out, amount)
+        ranked = rank_bridge_quotes(quotes, fee_converter=fee_to_usdc)
+    """
+
+    def __init__(self, bridges: Sequence[BaseBridge]) -> None:
+        if not bridges:
+            raise ValueError("BridgeRouter requires at least one bridge")
+        self.bridges: list[BaseBridge] = list(bridges)
+
+    async def quote_all(
+        self,
+        token_in: Token,
+        token_out: Token,
+        amount_in: TokenAmount,
+        **kwargs: Any,
+    ) -> list[BridgeQuote]:
+        """Fetch quotes from every bridge in parallel; drop BridgeError responses."""
+        results = await asyncio.gather(
+            *(bridge.get_quote(token_in, token_out, amount_in, **kwargs) for bridge in self.bridges),
+            return_exceptions=True,
+        )
+        quotes: list[BridgeQuote] = []
+        for result in results:
+            if isinstance(result, BridgeError):
+                continue
+            if isinstance(result, BaseException):
+                raise result
+            quotes.append(result)
+        return quotes

--- a/pydefi/types.py
+++ b/pydefi/types.py
@@ -423,7 +423,15 @@ class BridgeQuote:
         token_out: Destination token (on the destination chain).
         amount_in: Amount being sent.
         amount_out: Expected amount received after fees.
-        bridge_fee: Fee charged by the bridge (in *amount_in* token units).
+        bridge_fee: Fee charged by the bridge.  Most bridges deduct the fee
+            from ``amount_out`` and report it in ``token_in`` units, so
+            ``amount_in == amount_out + bridge_fee``.  Some bridges (notably
+            CCIP) charge the fee separately in a third token such as native
+            gas or LINK; in that case ``bridge_fee.token`` is neither
+            ``token_in`` nor ``token_out`` and ``amount_out`` is the gross
+            bridged amount.  Cross-bridge comparisons should go through
+            :func:`pydefi.bridge.rank_bridge_quotes`, which normalises both
+            shapes.
         estimated_time_seconds: Estimated bridge completion time.
         protocol: Bridge protocol name.
     """

--- a/tests/live/test_ccip_composer_fork.py
+++ b/tests/live/test_ccip_composer_fork.py
@@ -1,0 +1,704 @@
+"""Fork tests for CCIPComposer — Chainlink CCIP compose receiver backed by DeFiVM.
+
+These tests compile CCIPComposer.sol and DeFiVM.sol with py-solc-x, deploy them
+alongside mock contracts on a local Anvil fork of Ethereum mainnet, and exercise
+the full ``ccipReceive`` flow including:
+
+ - Basic compose execution via a mock CCIP Router
+ - Multi-call compose execution (two CALL instructions in one program)
+ - Compose execution carrying ETH value to a sub-call
+ - The prologue pushes (amountReceived, sourceChainSelector) onto the stack
+ - Composed event payload
+ - Revert when the caller is not the authorised Router
+ - Revert when ``destTokenAmounts`` has an unexpected length
+ - Revert when a sub-call inside the compose fails
+ - Owner rescue of stuck ETH and ERC-20 tokens
+
+Run with::
+
+    pytest -m fork tests/live/test_ccip_composer_fork.py
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import pytest
+import solcx
+from eth_contract import Contract
+from hexbytes import HexBytes
+from web3 import AsyncWeb3, Web3
+from web3.exceptions import ContractLogicError, Web3RPCError
+
+from pydefi.types import Address
+from pydefi.vm.program import (
+    call,
+    pop,
+    push_addr,
+    push_bytes,
+    push_u256,
+    store_reg,
+)
+from tests.live.sol_utils import compile_sol_file, deploy, ensure_solc
+
+# Reusable "this should revert" matcher for both anvil-direct and forked reverts.
+_REVERT = (ContractLogicError, Web3RPCError)
+_ZERO_ADDRESS = "0x" + "00" * 20
+_DEFAULT_MESSAGE_ID = b"\x00" * 32
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SOL_FILE = REPO_ROOT / "pydefi" / "bridge" / "CCIPComposer.sol"
+DEFI_VM_SOL_FILE = REPO_ROOT / "pydefi" / "vm" / "DeFiVM.sol"
+
+# Spot-check a CCIP chain selector (Ethereum mainnet).
+_ETHEREUM_SELECTOR = 5009297550715157269
+
+
+# ---------------------------------------------------------------------------
+# Mock contracts Solidity source
+# ---------------------------------------------------------------------------
+
+_MOCK_CONTRACTS_SOL = """
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+struct EVMTokenAmount {
+    address token;
+    uint256 amount;
+}
+
+struct Any2EVMMessage {
+    bytes32 messageId;
+    uint64 sourceChainSelector;
+    bytes sender;
+    bytes data;
+    EVMTokenAmount[] destTokenAmounts;
+}
+
+interface ICCIPComposer {
+    function ccipReceive(Any2EVMMessage calldata message) external payable;
+}
+
+/// @notice Minimal mock CCIP Router.  Controls which address may call
+///         ``ccipReceive`` on the composer and lets tests assemble inbound
+///         ``Any2EVMMessage`` structs from individual fields.
+contract MockRouter {
+    /// @notice Deliver a CCIP compose message to a composer contract.
+    ///
+    /// In real CCIP, the destination Router transfers the bridged token to the
+    /// receiver and then invokes ``ccipReceive``.  The mock router does only
+    /// the second step — the test mints the token to the composer directly.
+    function deliverCompose(
+        address _composer,
+        bytes32 _messageId,
+        uint64 _sourceChainSelector,
+        bytes calldata _sender,
+        bytes calldata _data,
+        address _token,
+        uint256 _amount
+    ) external payable {
+        EVMTokenAmount[] memory tokens = new EVMTokenAmount[](1);
+        tokens[0] = EVMTokenAmount({token: _token, amount: _amount});
+
+        Any2EVMMessage memory message = Any2EVMMessage({
+            messageId: _messageId,
+            sourceChainSelector: _sourceChainSelector,
+            sender: _sender,
+            data: _data,
+            destTokenAmounts: tokens
+        });
+
+        ICCIPComposer(_composer).ccipReceive{value: msg.value}(message);
+    }
+
+    /// @notice Deliver a CCIP message with an arbitrary ``destTokenAmounts``
+    ///         length so tests can exercise the ``UnexpectedTokenCount`` path.
+    function deliverComposeManyTokens(
+        address _composer,
+        bytes32 _messageId,
+        uint64 _sourceChainSelector,
+        bytes calldata _sender,
+        bytes calldata _data,
+        EVMTokenAmount[] calldata _tokens
+    ) external payable {
+        Any2EVMMessage memory message = Any2EVMMessage({
+            messageId: _messageId,
+            sourceChainSelector: _sourceChainSelector,
+            sender: _sender,
+            data: _data,
+            destTokenAmounts: _tokens
+        });
+
+        ICCIPComposer(_composer).ccipReceive{value: msg.value}(message);
+    }
+}
+
+/// @notice Minimal mintable ERC-20 (matches MockToken in sol_utils).
+contract MockERC20 {
+    string public name = "Mock";
+    string public symbol = "MOCK";
+    uint8 public decimals = 18;
+
+    mapping(address => uint256) public balanceOf;
+    uint256 public totalSupply;
+
+    function mint(address to, uint256 amount) external {
+        balanceOf[to] += amount;
+        totalSupply += amount;
+    }
+
+    function transfer(address to, uint256 amount) external returns (bool) {
+        require(balanceOf[msg.sender] >= amount, "insufficient");
+        balanceOf[msg.sender] -= amount;
+        balanceOf[to] += amount;
+        return true;
+    }
+}
+
+/// @notice Mock target contract — records the most recent call.
+contract MockTarget {
+    event Called(address sender, uint256 value, bytes data);
+
+    uint256 public callCount;
+    bytes public lastData;
+    uint256 public lastValue;
+
+    function execute(bytes calldata data) external payable returns (bool) {
+        callCount++;
+        lastData = data;
+        lastValue = msg.value;
+        emit Called(msg.sender, msg.value, data);
+        return true;
+    }
+
+    receive() external payable {}
+}
+
+/// @notice Mock target that always reverts.
+contract RevertingTarget {
+    error AlwaysReverts();
+
+    fallback() external payable {
+        revert AlwaysReverts();
+    }
+}
+"""
+
+
+def _compile_mock_contracts() -> dict[str, dict]:
+    ensure_solc("0.8.24")
+    result = solcx.compile_source(
+        _MOCK_CONTRACTS_SOL,
+        output_values=["abi", "bin"],
+        solc_version="0.8.24",
+    )
+    return {
+        "MockRouter": result["<stdin>:MockRouter"],
+        "MockERC20": result["<stdin>:MockERC20"],
+        "MockTarget": result["<stdin>:MockTarget"],
+        "RevertingTarget": result["<stdin>:RevertingTarget"],
+    }
+
+
+def _compile_ccip_composer() -> dict:
+    return compile_sol_file(SOL_FILE, "CCIPComposer")
+
+
+def _compile_defi_vm() -> dict:
+    return compile_sol_file(DEFI_VM_SOL_FILE, "DeFiVM")
+
+
+async def _deploy(w3: AsyncWeb3, compiled: dict, deployer: Address, *args) -> Address:
+    return await deploy(w3, compiled, deployer, *args)
+
+
+# ---------------------------------------------------------------------------
+# Module-scoped fork + deploy fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+async def ccip_fork_w3(fork_w3_module):
+    return fork_w3_module
+
+
+@pytest.fixture(scope="module")
+def compiled_ccip_composer():
+    return _compile_ccip_composer()
+
+
+@pytest.fixture(scope="module")
+def compiled_mocks():
+    return _compile_mock_contracts()
+
+
+@pytest.fixture(scope="module")
+def compiled_defi_vm():
+    return _compile_defi_vm()
+
+
+@pytest.fixture(scope="module")
+async def ctx(ccip_fork_w3, compiled_ccip_composer, compiled_mocks, compiled_defi_vm, interpreter_addr):
+    """Deploy CCIPComposer, DeFiVM, and mock contracts once; share across tests."""
+    w3 = ccip_fork_w3
+    accounts = await w3.eth.accounts
+    deployer = accounts[0]
+
+    router_address = await _deploy(w3, compiled_mocks["MockRouter"], deployer)
+    vm_address = await _deploy(w3, compiled_defi_vm, deployer, interpreter_addr)
+    composer_address = await _deploy(
+        w3,
+        compiled_ccip_composer,
+        deployer,
+        router_address,  # _router
+        vm_address,  # _vm
+        deployer,  # _owner
+        False,  # _allowlistEnabled — module-scoped fixture keeps the open
+        #                                  default so existing tests can drive
+        #                                  arbitrary senders.  A dedicated test
+        #                                  deploys a separate composer with the
+        #                                  allowlist enabled at construction.
+    )
+
+    token_address = await _deploy(w3, compiled_mocks["MockERC20"], deployer)
+    target_address = await _deploy(w3, compiled_mocks["MockTarget"], deployer)
+    reverting_address = await _deploy(w3, compiled_mocks["RevertingTarget"], deployer)
+
+    composer = Contract(abi=compiled_ccip_composer["abi"], tx={"to": Web3.to_checksum_address(composer_address)})
+    router = Contract(abi=compiled_mocks["MockRouter"]["abi"], tx={"to": Web3.to_checksum_address(router_address)})
+    token = Contract(abi=compiled_mocks["MockERC20"]["abi"], tx={"to": Web3.to_checksum_address(token_address)})
+    target = Contract(abi=compiled_mocks["MockTarget"]["abi"], tx={"to": Web3.to_checksum_address(target_address)})
+
+    return {
+        "w3": w3,
+        "accounts": accounts,
+        "deployer": deployer,
+        "composer": composer,
+        "composer_address": composer_address,
+        "router": router,
+        "router_address": router_address,
+        "vm_address": vm_address,
+        "token": token,
+        "token_address": token_address,
+        "target": target,
+        "target_address": target_address,
+        "reverting_address": reverting_address,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+def _call_target(target_address: Address, calldata: bytes, value: int = 0) -> bytes:
+    """DeFiVM bytecode for one external CALL that discards the success flag."""
+    return (
+        push_u256(0)
+        + push_u256(0)  # retLen=0, retOffset=0
+        + push_bytes(calldata)
+        + push_u256(value)
+        + push_addr(target_address)
+        + bytes([0x5A])  # GAS — forward all remaining gas
+        + call()
+        + pop()  # discard success flag
+    )
+
+
+def _prologue(*body: bytes) -> bytes:
+    """Save the (sourceChainSelector, amountReceived) the composer pushes into
+    R0 / R1, then run *body*.  Every compose program in this file opens with
+    this prologue, so callers can stop repeating ``store_reg(0) + store_reg(1)``.
+    """
+    return store_reg(0) + store_reg(1) + b"".join(body)
+
+
+def _program_calling(target_address: Address, calldata: bytes, value: int = 0) -> bytes:
+    """Full compose program: standard prologue + a single CALL into *target*."""
+    return _prologue(_call_target(target_address, calldata, value))
+
+
+async def _deliver(
+    ctx: dict,
+    program: bytes,
+    *,
+    amount: int = 10**18,
+    sender: bytes = b"",
+    message_id: bytes = _DEFAULT_MESSAGE_ID,
+    value: int = 0,
+    composer_address: Address | None = None,
+    mint: bool = True,
+):
+    """Mint *amount* tokens to the composer (when ``mint=True``) and deliver a
+    compose message through the mock Router.
+
+    Returns the transaction receipt.  Pass ``composer_address`` to target a
+    composer other than the one in the shared fixture (used by the
+    deploy-time-hardened test).
+    """
+    w3 = ctx["w3"]
+    deployer = ctx["deployer"]
+    composer_addr = composer_address or ctx["composer_address"]
+    if mint and amount > 0:
+        await ctx["token"].fns.mint(composer_addr, amount).transact(w3, deployer)
+    transact_kwargs = {"value": value} if value else {}
+    return (
+        await ctx["router"]
+        .fns.deliverCompose(
+            composer_addr,
+            message_id,
+            _ETHEREUM_SELECTOR,
+            sender,
+            HexBytes(program),
+            ctx["token_address"],
+            amount,
+        )
+        .transact(w3, deployer, **transact_kwargs)
+    )
+
+
+@asynccontextmanager
+async def _allowlist_on(ctx: dict, *, register: tuple[int, bytes] | None = None):
+    """Enable the source-side allowlist for the duration of the block.
+
+    When *register* is ``(selector, sender)``, also add that pair before
+    yielding.  Both flags / entries are reset on exit so the module-scoped
+    fixture stays clean for the next test.
+    """
+    composer = ctx["composer"]
+    w3 = ctx["w3"]
+    deployer = ctx["deployer"]
+    await composer.fns.setAllowlistEnabled(True).transact(w3, deployer)
+    if register is not None:
+        await composer.fns.setAllowed(*register, True).transact(w3, deployer)
+    try:
+        yield
+    finally:
+        if register is not None:
+            await composer.fns.setAllowed(*register, False).transact(w3, deployer)
+        await composer.fns.setAllowlistEnabled(False).transact(w3, deployer)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.fork
+class TestCCIPComposerFork:
+    """Fork-level tests for CCIPComposer.sol backed by DeFiVM on a local Anvil fork."""
+
+    # ------------------------------------------------------------------
+    # Happy-path compose flow
+    # ------------------------------------------------------------------
+
+    async def test_single_call_compose(self, ctx):
+        """ccipReceive runs a DeFiVM program that calls MockTarget.execute()."""
+        target = ctx["target"]
+        amount = 5 * 10**18
+        program = _program_calling(ctx["target_address"], target.fns.execute(b"ccip-hello").data)
+
+        pre_count = await target.fns.callCount().call(ctx["w3"])
+        pre_vm_bal = await ctx["token"].fns.balanceOf(ctx["vm_address"]).call(ctx["w3"])
+
+        receipt = await _deliver(ctx, program, amount=amount)
+        assert receipt["status"] == 1
+
+        assert await target.fns.callCount().call(ctx["w3"]) == pre_count + 1
+        assert await target.fns.lastData().call(ctx["w3"]) == b"ccip-hello"
+
+        # Composer transferred tokens to DeFiVM; composer keeps zero residual.
+        assert await ctx["token"].fns.balanceOf(ctx["composer_address"]).call(ctx["w3"]) == 0
+        assert await ctx["token"].fns.balanceOf(ctx["vm_address"]).call(ctx["w3"]) == pre_vm_bal + amount
+
+    async def test_multi_call_compose(self, ctx):
+        """A program with two sequential CALL instructions increments callCount by 2."""
+        target = ctx["target"]
+        target_address = ctx["target_address"]
+        program = _prologue(
+            _call_target(target_address, target.fns.execute(b"call_a").data),
+            _call_target(target_address, target.fns.execute(b"call_b").data),
+        )
+
+        before = await target.fns.callCount().call(ctx["w3"])
+        receipt = await _deliver(ctx, program, amount=2 * 10**18, message_id=b"\x00" * 31 + b"\x01")
+        assert receipt["status"] == 1
+        assert await target.fns.callCount().call(ctx["w3"]) == before + 2
+
+    async def test_compose_with_eth_value(self, ctx):
+        """ETH attached to ccipReceive is forwarded to the DeFiVM sub-call."""
+        target = ctx["target"]
+        target_address = ctx["target_address"]
+        eth_value = 5 * 10**15  # 0.005 ETH
+        program = _program_calling(target_address, target.fns.execute(b"with-eth").data, value=eth_value)
+
+        pre_target = await ctx["w3"].eth.get_balance(target_address)
+        receipt = await _deliver(ctx, program, value=eth_value)
+        assert receipt["status"] == 1
+
+        assert await ctx["w3"].eth.get_balance(target_address) == pre_target + eth_value
+        assert await target.fns.lastValue().call(ctx["w3"]) == eth_value
+
+    async def test_zero_amount_skips_token_transfer(self, ctx):
+        """ccipReceive with amount=0 skips the token transfer but still runs the program."""
+        target = ctx["target"]
+        program = _program_calling(ctx["target_address"], target.fns.execute(b"zero").data)
+
+        before = await target.fns.callCount().call(ctx["w3"])
+        receipt = await _deliver(ctx, program, amount=0, mint=False)
+        assert receipt["status"] == 1
+        assert await target.fns.callCount().call(ctx["w3"]) == before + 1
+
+    async def test_composed_event(self, ctx):
+        """Composed(sourceChainSelector, messageId, token, amountReceived) is emitted."""
+        amount = 333 * 10**18
+        message_id = b"\xab" * 32
+        program = _program_calling(ctx["target_address"], ctx["target"].fns.execute(b"event").data)
+
+        receipt = await _deliver(ctx, program, amount=amount, message_id=message_id)
+        assert receipt["status"] == 1
+
+        events = ctx["composer"].events.Composed.parse_logs(receipt["logs"])
+        assert len(events) == 1
+        evt = events[0]["args"]
+        assert evt["sourceChainSelector"] == _ETHEREUM_SELECTOR
+        assert HexBytes(evt["messageId"]) == HexBytes(message_id)
+        assert HexBytes(evt["token"]) == HexBytes(ctx["token_address"])
+        assert evt["amountReceived"] == amount
+
+    # ------------------------------------------------------------------
+    # Negative paths: caller + payload validation, sub-call rollback
+    # ------------------------------------------------------------------
+
+    async def test_unauthorized_router_reverts(self, ctx):
+        """Direct call to ccipReceive from a non-router address reverts."""
+        msg = (
+            _DEFAULT_MESSAGE_ID,
+            _ETHEREUM_SELECTOR,
+            b"",  # sender
+            HexBytes(_prologue()),
+            ((ctx["token_address"], 0),),
+        )
+        with pytest.raises(_REVERT):
+            await ctx["composer"].fns.ccipReceive(msg).transact(ctx["w3"], ctx["deployer"])
+
+    @pytest.mark.parametrize("tokens", [(), "many"], ids=["zero", "many"])
+    async def test_unexpected_token_count_reverts(self, ctx, tokens):
+        """ccipReceive reverts when destTokenAmounts is empty or has >1 entry."""
+        if tokens == "many":
+            tokens = ((ctx["token_address"], 1), (ctx["token_address"], 2))
+        with pytest.raises(_REVERT):
+            await (
+                ctx["router"]
+                .fns.deliverComposeManyTokens(
+                    ctx["composer_address"],
+                    _DEFAULT_MESSAGE_ID,
+                    _ETHEREUM_SELECTOR,
+                    b"",
+                    HexBytes(_prologue()),
+                    tokens,
+                )
+                .transact(ctx["w3"], ctx["deployer"])
+            )
+
+    async def test_sub_call_failure_reverts(self, ctx):
+        """A failing CALL in the program reverts the entire compose transaction."""
+        target = ctx["target"]
+        target_address = ctx["target_address"]
+        reverting_address = ctx["reverting_address"]
+
+        # First sub-call succeeds; second goes to a reverting target.
+        program = _prologue(
+            _call_target(target_address, target.fns.execute(b"before-fail").data),
+            push_u256(0)
+            + push_u256(0)
+            + push_bytes(b"")
+            + push_u256(0)
+            + push_addr(reverting_address)
+            + bytes([0x5A])
+            + call(),
+        )
+
+        before = await target.fns.callCount().call(ctx["w3"])
+        with pytest.raises(_REVERT):
+            await _deliver(ctx, program)
+        # The first CALL's increment must have been rolled back.
+        assert await target.fns.callCount().call(ctx["w3"]) == before
+
+    # ------------------------------------------------------------------
+    # Owner rescue + ownership transfer
+    # ------------------------------------------------------------------
+
+    async def test_rescue_eth(self, ctx):
+        """Owner can rescue ETH stuck in the composer.
+
+        Mirrors the proven idiom from :mod:`tests.live.test_oft_composer_fork`:
+        fund the composer via a normal ``send_transaction`` (rather than
+        ``anvil_setBalance``, whose behaviour varies between anvil builds and
+        was producing a silent no-op rescue here), send the rescue to a fresh
+        ephemeral recipient that no prior test has touched, and assert both
+        the composer and recipient balances move by exactly ``eth_amount``.
+        """
+        w3 = ctx["w3"]
+        composer_address = ctx["composer_address"]
+        deployer = ctx["deployer"]
+        eth_amount = 5 * 10**17  # 0.5 ETH
+
+        tx_hash = await w3.eth.send_transaction(
+            {"from": deployer, "to": Web3.to_checksum_address(composer_address), "value": eth_amount}
+        )
+        await w3.eth.wait_for_transaction_receipt(tx_hash, timeout=60, poll_latency=0.1)
+
+        before_composer = await w3.eth.get_balance(composer_address)
+        assert before_composer >= eth_amount
+
+        fresh_recipient = w3.eth.account.create().address
+        assert await w3.eth.get_balance(fresh_recipient) == 0
+
+        receipt = await ctx["composer"].fns.rescueETH(fresh_recipient, eth_amount).transact(w3, deployer)
+        assert receipt["status"] == 1
+        assert await w3.eth.get_balance(composer_address) == before_composer - eth_amount
+        assert await w3.eth.get_balance(fresh_recipient) == eth_amount
+
+    async def test_rescue_token(self, ctx):
+        """Owner can rescue ERC-20 tokens stuck in the composer."""
+        token = ctx["token"]
+        amount = 7 * 10**18
+
+        await token.fns.mint(ctx["composer_address"], amount).transact(ctx["w3"], ctx["deployer"])
+
+        # Use a fresh ephemeral recipient so any tokens left over from earlier
+        # tests in this module's ctx cannot influence the post-balance check.
+        fresh_recipient = ctx["w3"].eth.account.create().address
+        assert await token.fns.balanceOf(fresh_recipient).call(ctx["w3"]) == 0
+
+        receipt = (
+            await ctx["composer"]
+            .fns.rescueToken(ctx["token_address"], fresh_recipient, amount)
+            .transact(ctx["w3"], ctx["deployer"])
+        )
+        assert receipt["status"] == 1
+        assert await token.fns.balanceOf(fresh_recipient).call(ctx["w3"]) == amount
+
+    @pytest.mark.parametrize(
+        "fn_name,args_idx",
+        [
+            ("rescueETH", "non_owner_then_1"),
+            ("setAllowlistEnabled", "true"),
+            ("setAllowed", "default_entry"),
+        ],
+    )
+    async def test_only_owner(self, ctx, fn_name, args_idx):
+        """Owner-gated functions revert when called by anyone else."""
+        non_owner = ctx["accounts"][2]
+        args = {
+            "non_owner_then_1": (non_owner, 1),
+            "true": (True,),
+            "default_entry": (_ETHEREUM_SELECTOR, b"\xcc" * 32, True),
+        }[args_idx]
+        with pytest.raises(_REVERT):
+            await getattr(ctx["composer"].fns, fn_name)(*args).transact(ctx["w3"], non_owner)
+
+    async def test_transfer_ownership(self, ctx):
+        """transferOwnership updates owner and emits OwnershipTransferred."""
+        composer = ctx["composer"]
+        w3 = ctx["w3"]
+        deployer = ctx["deployer"]
+        new_owner = ctx["accounts"][3]
+
+        old_owner = await composer.fns.owner().call(w3)
+        receipt = await composer.fns.transferOwnership(new_owner).transact(w3, deployer)
+        assert receipt["status"] == 1
+        assert HexBytes(await composer.fns.owner().call(w3)) == HexBytes(new_owner)
+
+        events = composer.events.OwnershipTransferred.parse_logs(receipt["logs"])
+        assert len(events) == 1
+        assert HexBytes(events[0]["args"]["previousOwner"]) == HexBytes(old_owner)
+        assert HexBytes(events[0]["args"]["newOwner"]) == HexBytes(new_owner)
+
+        # Restore ownership so subsequent tests in this module still pass.
+        await composer.fns.transferOwnership(deployer).transact(w3, new_owner)
+
+    # ------------------------------------------------------------------
+    # Constructor guards
+    # ------------------------------------------------------------------
+
+    @pytest.mark.parametrize("zero_arg", ["router", "vm", "owner"])
+    async def test_constructor_rejects_zero_address(self, ctx, zero_arg):
+        """Deploying CCIPComposer with router/vm/owner = 0 reverts."""
+        w3 = ctx["w3"]
+        deployer = ctx["deployer"]
+        compiled = _compile_ccip_composer()
+
+        # All three positions default to valid checksum addresses; flip one to zero.
+        ctor_args: dict[str, str] = {
+            "router": Web3.to_checksum_address(ctx["router_address"]),
+            "vm": Web3.to_checksum_address(ctx["vm_address"]),
+            "owner": deployer,
+        }
+        ctor_args[zero_arg] = _ZERO_ADDRESS
+
+        contract = w3.eth.contract(abi=compiled["abi"], bytecode=compiled["bin"])
+        with pytest.raises(_REVERT):
+            tx_hash = await contract.constructor(
+                ctor_args["router"], ctor_args["vm"], ctor_args["owner"], False
+            ).transact({"from": deployer})
+            await w3.eth.wait_for_transaction_receipt(tx_hash, timeout=30, poll_latency=0.1)
+
+    async def test_constructor_can_enable_allowlist_at_deploy(self, ctx):
+        """Deploying with ``_allowlistEnabled=true`` boots the composer in a
+        fail-closed posture: an inbound message from an unregistered
+        ``(selector, sender)`` reverts immediately.
+        """
+        w3 = ctx["w3"]
+        deployer = ctx["deployer"]
+        compiled = _compile_ccip_composer()
+        hardened_address = await deploy(
+            w3,
+            compiled,
+            deployer,
+            Web3.to_checksum_address(ctx["router_address"]),
+            Web3.to_checksum_address(ctx["vm_address"]),
+            deployer,
+            True,  # _allowlistEnabled
+        )
+        hardened = Contract(abi=compiled["abi"], tx={"to": Web3.to_checksum_address(hardened_address)})
+
+        assert await hardened.fns.allowlistEnabled().call(w3) is True
+
+        # An inbound message with an unregistered sender must revert.
+        with pytest.raises(_REVERT):
+            await _deliver(
+                ctx,
+                _prologue(),
+                composer_address=hardened_address,
+                sender=b"\xaa" * 32,
+            )
+
+    # ------------------------------------------------------------------
+    # Source-side allowlist
+    # ------------------------------------------------------------------
+
+    async def test_allowlist_disabled_by_default(self, ctx):
+        """allowlistEnabled is false right after deployment."""
+        assert await ctx["composer"].fns.allowlistEnabled().call(ctx["w3"]) is False
+
+    async def test_allowlist_blocks_unregistered_sender(self, ctx):
+        """When the allowlist is on, an unregistered sender cannot trigger compose."""
+        async with _allowlist_on(ctx):
+            with pytest.raises(_REVERT):
+                await _deliver(ctx, _prologue(), sender=b"\xaa" * 32)
+
+    async def test_allowlist_admits_registered_sender(self, ctx):
+        """A registered (selector, sender) pair passes the allowlist check."""
+        sender_bytes = b"\xbb" * 32
+        target = ctx["target"]
+        program = _program_calling(ctx["target_address"], target.fns.execute(b"allowed").data)
+
+        async with _allowlist_on(ctx, register=(_ETHEREUM_SELECTOR, sender_bytes)):
+            receipt = await _deliver(ctx, program, sender=sender_bytes)
+            assert receipt["status"] == 1

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -1428,6 +1428,32 @@ class TestRankBridgeQuotes:
         assert ranked[1].fee_unranked is True
         assert ranked[1].effective_amount_out == 100_000_000  # not penalised
 
+    def test_ccip_with_fee_in_token_in_is_not_treated_as_netted(self):
+        """CCIP fee in token_in (e.g. USDC-as-fee bridging USDC) has
+        amount_out == amount_in but a separate non-zero fee — the fast-path
+        must not fire.
+        """
+        q = BridgeQuote(
+            token_in=USDC_ETH,
+            token_out=USDC_ARB,
+            amount_in=TokenAmount(USDC_ETH, 100_000_000),
+            amount_out=TokenAmount(USDC_ARB, 100_000_000),  # CCIP is 1:1
+            bridge_fee=TokenAmount(USDC_ETH, 500_000),  # 0.5 USDC fee on top
+            estimated_time_seconds=600,
+            protocol="CCIP",
+        )
+
+        # Without a converter the quote is unrankable, not silently fee-free.
+        unranked = rank_bridge_quotes([q])[0]
+        assert unranked.fee_unranked is True
+        assert unranked.fee_in_token_out_units == 0
+
+        # With a converter the fee is subtracted from amount_out.
+        ranked = rank_bridge_quotes([q], fee_converter=lambda r: r.bridge_fee.amount)[0]
+        assert ranked.fee_unranked is False
+        assert ranked.fee_in_token_out_units == 500_000
+        assert ranked.effective_amount_out == 100_000_000 - 500_000
+
     def test_converter_lets_ccip_compete(self):
         """0.002 ETH ≈ 6 USDC fee outweighs CCTP's 0.2 USDC margin."""
         legacy = _legacy_quote(amount_out=99_800_000, fee=200_000)

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -7,6 +7,12 @@ from hexbytes import HexBytes
 
 from pydefi.bridge.across import Across
 from pydefi.bridge.base import BaseBridge
+from pydefi.bridge.ccip import (
+    _CCIP_CHAIN_SELECTOR,
+    _CCIP_ROUTER,
+    CCIP,
+    EVM_EXTRA_ARGS_V2_TAG,
+)
 from pydefi.bridge.cctp import (
     HYPERCORE_DEX_PERP,
     HYPERCORE_DEX_SPOT,
@@ -16,9 +22,10 @@ from pydefi.bridge.gaszip import _SUPPORTED_CHAINS, GasZip
 from pydefi.bridge.layerzero_oft import _LZ_EID, LayerZeroOFT
 from pydefi.bridge.mayan import _CHAIN_NAMES, _MAYAN_FORWARDER, Mayan
 from pydefi.bridge.relay import Relay
+from pydefi.bridge.router import BridgeRouter, rank_bridge_quotes
 from pydefi.bridge.stargate import _LZ_CHAIN_ID, _POOL_IDS, Stargate
 from pydefi.exceptions import BridgeError
-from pydefi.types import Address, ChainId, Token, TokenAmount
+from pydefi.types import Address, BridgeQuote, ChainId, Token, TokenAmount
 from tests.addrs import ETH_WHALE, USDC, WETH
 
 
@@ -989,3 +996,501 @@ class TestEncodeCctpForwardHookData:
         data = encode_cctp_forward_hook_data(recipient=HexBytes(addr_no_prefix))
         expected_addr = bytes.fromhex(addr_no_prefix)
         assert data[32:52] == expected_addr
+
+
+# ---------------------------------------------------------------------------
+# CCIP tests
+# ---------------------------------------------------------------------------
+
+# Canonical CCIP Router function selectors.
+_CCIP_SEND_SELECTOR = "96f4e9f9"  # ccipSend(uint64,(bytes,bytes,(address,uint256)[],address,bytes))
+_CCIP_GET_FEE_SELECTOR = "20487ded"  # getFee(uint64,(bytes,bytes,(address,uint256)[],address,bytes))
+
+
+# ---- Shared CCIP fixtures and constants -----------------------------------
+
+CCIP_USDC_ETH = Token(chain_id=ChainId.ETHEREUM, address=USDC.address, symbol="USDC", decimals=6)
+CCIP_USDC_ARB = Token(
+    chain_id=ChainId.ARBITRUM,
+    address=Address("0xaf88d065e77c8cC2239327C5EDb3A432268e5831"),
+    symbol="USDC",
+    decimals=6,
+)
+_CCIP_RECIPIENT: Address = Address("0x" + "AA" * 20)
+_CCIP_COMPOSER: Address = Address("0x" + "CC" * 20)
+
+
+@pytest.fixture
+def ccip() -> CCIP:
+    """Vanilla CCIP for Ethereum→Arbitrum, native fee."""
+    return CCIP(w3=None, src_chain_id=1, dst_chain_id=42161)
+
+
+@pytest.fixture
+def amount_in() -> TokenAmount:
+    """100 USDC on Ethereum side — the default amount across CCIP tests."""
+    return TokenAmount.from_human(CCIP_USDC_ETH, "100")
+
+
+def _patched_quote_fee(ccip: CCIP, fee: int):
+    """Stub ``ccip.quote_fee`` so build_*_tx skips its on-chain call."""
+    return patch.object(ccip, "quote_fee", new=AsyncMock(return_value=fee))
+
+
+def _mock_ccip_router(call: AsyncMock) -> tuple[MagicMock, MagicMock]:
+    """Build a fake ``CCIP_ROUTER`` module constant and return ``(router, get_fee_factory)``.
+
+    Patch via ``patch("pydefi.bridge.ccip.CCIP_ROUTER", router)`` and inspect
+    invocations through ``get_fee_factory.call_args``.
+    """
+    mock_get_fee = MagicMock(return_value=MagicMock(call=call))
+    mock_router = MagicMock()
+    mock_router.fns.getFee = mock_get_fee
+    return mock_router, mock_get_fee
+
+
+class TestCCIP:
+    # -- construction + registry --------------------------------------------
+
+    def test_protocol_name(self, ccip):
+        assert ccip.protocol_name == "CCIP"
+
+    def test_router_address_defaults_to_registry(self, ccip):
+        assert ccip.router_address == _CCIP_ROUTER[1]
+
+    def test_router_address_override(self):
+        custom = "0x" + "11" * 20
+        assert CCIP(w3=None, src_chain_id=1, dst_chain_id=42161, router_address=custom).router_address == custom
+
+    def test_unknown_src_chain_raises(self):
+        with pytest.raises(BridgeError, match="Router"):
+            CCIP(w3=None, src_chain_id=999999, dst_chain_id=42161)
+
+    def test_unknown_dst_chain_raises(self):
+        with pytest.raises(BridgeError, match="chain selector"):
+            CCIP(w3=None, src_chain_id=1, dst_chain_id=999999)
+
+    def test_dst_chain_selector_resolved(self, ccip):
+        assert ccip.dst_chain_selector == _CCIP_CHAIN_SELECTOR[42161]
+
+    def test_fee_token_defaults_to_zero(self, ccip):
+        """fee_token=None means pay in native gas (zero address)."""
+        assert bytes(ccip.fee_token) == b"\x00" * 20
+
+    # -- fee_token_decimals validation --------------------------------------
+
+    def test_fee_token_decimals_defaults_to_18(self, ccip):
+        assert ccip.fee_token_decimals == 18
+
+    def test_fee_token_decimals_override(self):
+        """Caller can specify a non-18-decimal fee token (e.g. USDC=6)."""
+        c = CCIP(
+            w3=None,
+            src_chain_id=1,
+            dst_chain_id=42161,
+            fee_token=Address("0x" + "A0" * 20),
+            fee_token_decimals=6,
+            fee_token_symbol="USDC",
+        )
+        assert c.fee_token_decimals == 6
+        assert c.fee_token_symbol == "USDC"
+
+    @pytest.mark.parametrize(
+        "value,match",
+        [
+            (-1, r"\[0, 36\]"),
+            (37, r"\[0, 36\]"),
+            # bool subclasses int — common gotcha; explicit type check rejects it.
+            (True, "must be an int"),
+            (18.0, "must be an int"),
+        ],
+        ids=["negative", "above_36", "bool", "float"],
+    )
+    def test_fee_token_decimals_rejected(self, value, match):
+        with pytest.raises(BridgeError, match=match):
+            CCIP(w3=None, src_chain_id=1, dst_chain_id=42161, fee_token_decimals=value)
+
+    def test_fee_token_decimals_accepts_zero(self):
+        """0 is a legal precision (sub-units only)."""
+        assert CCIP(w3=None, src_chain_id=1, dst_chain_id=42161, fee_token_decimals=0).fee_token_decimals == 0
+
+    @pytest.mark.asyncio
+    async def test_get_quote_uses_fee_token_decimals(self, amount_in):
+        """The synthetic fee Token in bridge_fee carries the decimals override."""
+        usdc = Address("0x" + "A0" * 20)
+        c = CCIP(
+            w3=None,
+            src_chain_id=1,
+            dst_chain_id=42161,
+            fee_token=usdc,
+            fee_token_decimals=6,
+            fee_token_symbol="USDC",
+        )
+        with _patched_quote_fee(c, 1_500_000):
+            q = await c.get_quote(CCIP_USDC_ETH, CCIP_USDC_ARB, amount_in)
+        assert q.bridge_fee.token.decimals == 6
+        assert q.bridge_fee.token.symbol == "USDC"
+        assert bytes(q.bridge_fee.token.address) == bytes(usdc)
+
+    # -- quote_fee on-chain wrapper -----------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_quote_fee_calls_getfee(self, ccip, amount_in):
+        """quote_fee calls Router.getFee and returns its uint256."""
+        router_mock, get_fee_mock = _mock_ccip_router(AsyncMock(return_value=5 * 10**15))
+        with patch("pydefi.bridge.ccip.CCIP_ROUTER", router_mock):
+            fee = await ccip.quote_fee(CCIP_USDC_ETH, amount_in, _CCIP_RECIPIENT)
+        assert fee == 5 * 10**15
+        get_fee_mock.assert_called_once()
+        # First positional arg is the destination chain selector.
+        assert get_fee_mock.call_args.args[0] == _CCIP_CHAIN_SELECTOR[42161]
+
+    @pytest.mark.asyncio
+    async def test_quote_fee_wraps_revert(self, ccip, amount_in):
+        """A reverting getFee call surfaces as BridgeError."""
+        router_mock, _ = _mock_ccip_router(AsyncMock(side_effect=RuntimeError("execution reverted")))
+        with patch("pydefi.bridge.ccip.CCIP_ROUTER", router_mock):
+            with pytest.raises(BridgeError, match="getFee"):
+                await ccip.quote_fee(CCIP_USDC_ETH, amount_in, _CCIP_RECIPIENT)
+
+    # -- get_quote / build_bridge_tx ----------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_get_quote(self, ccip, amount_in):
+        """get_quote returns a 1:1 token amount with the fee separated."""
+        with _patched_quote_fee(ccip, 5 * 10**15):
+            q = await ccip.get_quote(CCIP_USDC_ETH, CCIP_USDC_ARB, amount_in)
+        assert q.protocol == "CCIP"
+        assert q.amount_out.amount == amount_in.amount  # CCIP is 1:1
+        assert q.bridge_fee.amount == 5 * 10**15
+        assert bytes(q.bridge_fee.token.address) == b"\x00" * 20  # native default
+        assert q.estimated_time_seconds > 0
+
+    @pytest.mark.asyncio
+    async def test_build_bridge_tx_native_fee(self, ccip, amount_in):
+        """Native fee → tx.value carries the fee, tx.to is the Router."""
+        with _patched_quote_fee(ccip, 5 * 10**15):
+            tx = await ccip.build_bridge_tx(CCIP_USDC_ETH, CCIP_USDC_ARB, amount_in, _CCIP_RECIPIENT)
+        assert tx["to"] == _CCIP_ROUTER[1]
+        assert tx["data"].startswith("0x" + _CCIP_SEND_SELECTOR)
+        assert tx["value"] == str(5 * 10**15)
+        assert int(tx["gas"]) > 0
+
+    @pytest.mark.asyncio
+    async def test_build_bridge_tx_erc20_fee(self, amount_in):
+        """ERC-20 fee → tx.value is 0; caller approves fee token separately."""
+        link = Address("0x" + "CC" * 20)
+        c = CCIP(w3=None, src_chain_id=1, dst_chain_id=42161, fee_token=link)
+        with _patched_quote_fee(c, 42 * 10**18):
+            tx = await c.build_bridge_tx(CCIP_USDC_ETH, CCIP_USDC_ARB, amount_in, _CCIP_RECIPIENT)
+        assert tx["value"] == "0"
+        assert link.hex().lower() in tx["data"].lower()
+
+    @pytest.mark.asyncio
+    async def test_build_bridge_tx_embeds_recipient(self, ccip, amount_in):
+        with _patched_quote_fee(ccip, 10**15):
+            tx = await ccip.build_bridge_tx(CCIP_USDC_ETH, CCIP_USDC_ARB, amount_in, _CCIP_RECIPIENT)
+        assert _CCIP_RECIPIENT.hex().lower() in tx["data"].lower()
+
+    @pytest.mark.asyncio
+    async def test_build_bridge_tx_uses_chain_selector(self, ccip, amount_in):
+        """The 64-bit dst chain selector is the first 32-byte arg after the function selector."""
+        with _patched_quote_fee(ccip, 10**15):
+            tx = await ccip.build_bridge_tx(CCIP_USDC_ETH, CCIP_USDC_ARB, amount_in, _CCIP_RECIPIENT)
+        body = tx["data"][2 + 8 :]  # strip 0x + selector
+        assert int(body[:64], 16) == _CCIP_CHAIN_SELECTOR[42161]
+
+    @pytest.mark.asyncio
+    async def test_build_bridge_tx_with_compose_payload(self, ccip, amount_in):
+        """A non-empty `data` payload is encoded into the message's data field."""
+        program = b"\xde\xad\xbe\xef" * 8
+        with _patched_quote_fee(ccip, 10**15):
+            tx = await ccip.build_bridge_tx(
+                CCIP_USDC_ETH,
+                CCIP_USDC_ARB,
+                amount_in,
+                _CCIP_RECIPIENT,
+                data=program,
+                gas_limit=200_000,
+            )
+        assert program.hex() in tx["data"].lower()
+
+    @pytest.mark.parametrize(
+        "gas_limit,allow_ooo,last_byte",
+        [
+            (200_000, True, b"\x01"),
+            (0, False, b"\x00"),
+        ],
+        ids=["gas=200k,ooo=True", "gas=0,ooo=False"],
+    )
+    @pytest.mark.asyncio
+    async def test_build_bridge_tx_extra_args_v2_layout(self, ccip, amount_in, gas_limit, allow_ooo, last_byte):
+        """``extraArgs`` is encoded as 0x181dcf10 ++ abi.encode(uint256 gas, bool ooo).
+
+        Verifies the v2 tag, the 68-byte total length, and that the gas_limit
+        and allow_out_of_order_execution flag round-trip through the public
+        ``build_bridge_tx`` calldata — covering what the deleted
+        encode_ccip_extra_args_v2 helper used to verify in isolation.
+        """
+        with _patched_quote_fee(ccip, 10**15):
+            tx = await ccip.build_bridge_tx(
+                CCIP_USDC_ETH,
+                CCIP_USDC_ARB,
+                amount_in,
+                _CCIP_RECIPIENT,
+                gas_limit=gas_limit,
+                allow_out_of_order_execution=allow_ooo,
+            )
+
+        # The complete 68-byte extraArgs blob must appear verbatim in the calldata.
+        expected = EVM_EXTRA_ARGS_V2_TAG + gas_limit.to_bytes(32, "big") + (b"\x00" * 31 + last_byte)
+        assert len(expected) == 4 + 32 + 32
+        assert EVM_EXTRA_ARGS_V2_TAG.hex() == "181dcf10"
+        assert expected.hex() in tx["data"].lower()
+
+    # -- canonical constants -------------------------------------------------
+
+    @pytest.mark.parametrize(
+        "chain_id,expected",
+        [
+            (1, 5009297550715157269),  # Ethereum
+            (42161, 4949039107694359620),  # Arbitrum
+            (8453, 15971525489660198786),  # Base
+            (10, 3734403246176062136),  # Optimism
+            (137, 4051577828743386545),  # Polygon
+            (43114, 6433500567565415381),  # Avalanche
+            (56, 11344663589394136015),  # BNB Chain
+            (59144, 4627098889531055414),  # Linea
+        ],
+    )
+    def test_chain_selector_constants(self, chain_id, expected):
+        """Spot-check published CCIP chain-selector values."""
+        assert _CCIP_CHAIN_SELECTOR[chain_id] == expected
+
+    def test_router_function_selectors(self):
+        """Verify the bound Router contract's encoded selectors match the published ones."""
+        from pydefi.abi.bridge import CCIP_ROUTER, CCIPEVM2AnyMessage, CCIPEVMTokenAmount
+
+        msg = CCIPEVM2AnyMessage(
+            receiver=b"\x00" * 32,
+            data=b"",
+            tokenAmounts=(CCIPEVMTokenAmount(token="0x" + "aa" * 20, amount=0),),
+            feeToken="0x" + "00" * 20,
+            extraArgs=b"",
+        )
+        assert CCIP_ROUTER.fns.ccipSend(0, msg).data.hex().startswith(_CCIP_SEND_SELECTOR)
+        assert CCIP_ROUTER.fns.getFee(0, msg).data.hex().startswith(_CCIP_GET_FEE_SELECTOR)
+
+
+class TestCCIPCompose:
+    """Tests for the CCIP compose flow (``build_bridge_compose_tx``)."""
+
+    @pytest.mark.asyncio
+    async def test_rejects_empty_program(self, ccip, amount_in):
+        with _patched_quote_fee(ccip, 10**15):
+            with pytest.raises(BridgeError, match="program"):
+                await ccip.build_bridge_compose_tx(CCIP_USDC_ETH, amount_in, _CCIP_COMPOSER, program=b"")
+
+    @pytest.mark.asyncio
+    async def test_embeds_program_in_data(self, ccip, amount_in):
+        """The DeFiVM bytecode appears verbatim inside the ccipSend calldata."""
+        program = b"\xde\xad\xbe\xef" * 16
+        with _patched_quote_fee(ccip, 10**15):
+            tx = await ccip.build_bridge_compose_tx(CCIP_USDC_ETH, amount_in, _CCIP_COMPOSER, program)
+        assert tx["data"].startswith("0x" + _CCIP_SEND_SELECTOR)
+        assert program.hex() in tx["data"].lower()
+
+    @pytest.mark.asyncio
+    async def test_receiver_is_composer(self, ccip, amount_in):
+        with _patched_quote_fee(ccip, 10**15):
+            tx = await ccip.build_bridge_compose_tx(
+                CCIP_USDC_ETH,
+                amount_in,
+                _CCIP_COMPOSER,
+                program=b"\x01\x02\x03\x04",
+            )
+        assert _CCIP_COMPOSER.hex().lower() in tx["data"].lower()
+
+    @pytest.mark.asyncio
+    async def test_quote_fee_called_with_program_and_gas_limit(self, ccip, amount_in):
+        """quote_fee receives the program payload and the requested gas_limit."""
+        program = b"\xaa" * 64
+        spy = AsyncMock(return_value=10**15)
+        with patch.object(ccip, "quote_fee", new=spy):
+            await ccip.build_bridge_compose_tx(
+                CCIP_USDC_ETH,
+                amount_in,
+                _CCIP_COMPOSER,
+                program,
+                gas_limit=1_500_000,
+            )
+        spy.assert_called_once()
+        assert spy.call_args.kwargs["data"] == program
+        assert spy.call_args.kwargs["gas_limit"] == 1_500_000
+
+    @pytest.mark.asyncio
+    async def test_native_fee_attaches_value(self, ccip, amount_in):
+        with _patched_quote_fee(ccip, 7 * 10**15):
+            tx = await ccip.build_bridge_compose_tx(
+                CCIP_USDC_ETH,
+                amount_in,
+                _CCIP_COMPOSER,
+                program=b"\xff" * 32,
+            )
+        assert tx["value"] == str(7 * 10**15)
+
+    @pytest.mark.asyncio
+    async def test_erc20_fee_token_zero_value(self, amount_in):
+        """ERC-20 fee_token → tx.value is 0; caller approves fee token separately."""
+        link = Address("0x" + "DD" * 20)
+        c = CCIP(w3=None, src_chain_id=1, dst_chain_id=42161, fee_token=link)
+        with _patched_quote_fee(c, 20 * 10**18):
+            tx = await c.build_bridge_compose_tx(
+                CCIP_USDC_ETH,
+                amount_in,
+                _CCIP_COMPOSER,
+                program=b"\xff" * 32,
+            )
+        assert tx["value"] == "0"
+        assert link.hex().lower() in tx["data"].lower()
+
+
+# ---------------------------------------------------------------------------
+# BridgeRouter / rank_bridge_quotes tests
+# ---------------------------------------------------------------------------
+
+_NATIVE_TOKEN = Token(
+    chain_id=ChainId.ETHEREUM,
+    address=Address("0x" + "00" * 20),
+    symbol="NATIVE",
+    decimals=18,
+)
+_ROUTER_AMOUNT = TokenAmount(USDC_ETH, 100_000_000)
+
+
+def _legacy_quote(amount_out: int, fee: int, protocol: str = "CCTP") -> BridgeQuote:
+    """A bridge whose fee is denominated in token_in — fee already baked into amount_out."""
+    return BridgeQuote(
+        token_in=USDC_ETH,
+        token_out=USDC_ARB,
+        amount_in=TokenAmount(USDC_ETH, 100_000_000),
+        amount_out=TokenAmount(USDC_ARB, amount_out),
+        bridge_fee=TokenAmount(USDC_ETH, fee),
+        estimated_time_seconds=180,
+        protocol=protocol,
+    )
+
+
+def _ccip_native_quote(amount_in: int, native_fee: int) -> BridgeQuote:
+    """A CCIP-style quote: amount_out == amount_in, fee in a separate native token."""
+    return BridgeQuote(
+        token_in=USDC_ETH,
+        token_out=USDC_ARB,
+        amount_in=TokenAmount(USDC_ETH, amount_in),
+        amount_out=TokenAmount(USDC_ARB, amount_in),
+        bridge_fee=TokenAmount(_NATIVE_TOKEN, native_fee),
+        estimated_time_seconds=600,
+        protocol="CCIP",
+    )
+
+
+def _native_fee_to_usdc(q: BridgeQuote) -> int | None:
+    """Test-only fee converter: NATIVE → USDC at 3000 USDC/ETH; everything else → None."""
+    if q.bridge_fee.token.symbol != "NATIVE":
+        return None
+    return q.bridge_fee.amount * 3000 * 10**6 // 10**18
+
+
+def _mock_bridge(*, quote: BridgeQuote | None = None, side_effect: BaseException | None = None) -> MagicMock:
+    """Build a fake BaseBridge whose ``get_quote`` returns a quote or raises."""
+    b = MagicMock(spec=BaseBridge)
+    if side_effect is not None:
+        b.get_quote = AsyncMock(side_effect=side_effect)
+    else:
+        b.get_quote = AsyncMock(return_value=quote)
+    return b
+
+
+class TestRankBridgeQuotes:
+    def test_legacy_quotes_compared_by_amount_out(self):
+        """Bridges with fee in token_in are ranked directly by amount_out."""
+        better = _legacy_quote(amount_out=99_900_000, fee=100_000, protocol="Across")
+        worse = _legacy_quote(amount_out=99_500_000, fee=500_000, protocol="Stargate")
+        ranked = rank_bridge_quotes([worse, better])
+        assert [r.protocol for r in ranked] == ["Across", "Stargate"]
+        assert all(r.fee_in_token_out_units == 0 and not r.fee_unranked for r in ranked)
+
+    def test_unconverted_ccip_is_marked_unranked_and_last(self):
+        legacy = _legacy_quote(amount_out=99_800_000, fee=200_000)
+        ccip = _ccip_native_quote(amount_in=100_000_000, native_fee=2 * 10**15)
+        ranked = rank_bridge_quotes([ccip, legacy])
+        assert [r.protocol for r in ranked] == ["CCTP", "CCIP"]
+        assert ranked[1].fee_unranked is True
+        assert ranked[1].effective_amount_out == 100_000_000  # not penalised
+
+    def test_converter_lets_ccip_compete(self):
+        """0.002 ETH ≈ 6 USDC fee outweighs CCTP's 0.2 USDC margin."""
+        legacy = _legacy_quote(amount_out=99_800_000, fee=200_000)
+        ccip = _ccip_native_quote(amount_in=100_000_000, native_fee=2 * 10**15)
+        ranked = rank_bridge_quotes([ccip, legacy], fee_converter=_native_fee_to_usdc)
+
+        ccip_r = next(r for r in ranked if r.protocol == "CCIP")
+        cctp_r = next(r for r in ranked if r.protocol == "CCTP")
+        assert ccip_r.fee_in_token_out_units == 6_000_000
+        assert ccip_r.effective_amount_out == 100_000_000 - 6_000_000
+        assert cctp_r.effective_amount_out > ccip_r.effective_amount_out
+        assert ranked[0].protocol == "CCTP"
+
+    def test_converter_returning_none_marks_unranked(self):
+        ccip = _ccip_native_quote(amount_in=100_000_000, native_fee=2 * 10**15)
+        ranked = rank_bridge_quotes([ccip], fee_converter=lambda _: None)
+        assert ranked[0].fee_unranked is True
+
+    def test_ccip_wins_when_fee_is_small(self):
+        """If the converted CCIP fee is small, CCIP can rank above legacy bridges."""
+        legacy = _legacy_quote(amount_out=99_500_000, fee=500_000)  # 0.5% legacy fee
+        ccip = _ccip_native_quote(amount_in=100_000_000, native_fee=10**14)  # ~0.3 USDC
+        ranked = rank_bridge_quotes([legacy, ccip], fee_converter=_native_fee_to_usdc)
+        assert ranked[0].protocol == "CCIP"
+        assert ranked[0].effective_amount_out > ranked[1].effective_amount_out
+
+    def test_unrankable_quotes_keep_input_order(self):
+        """Unrankable quotes preserve insertion order (stable sort)."""
+        q1 = _ccip_native_quote(amount_in=100_000_000, native_fee=10**15)
+        q1.protocol = "first"
+        q2 = _ccip_native_quote(amount_in=100_000_000, native_fee=10**15)
+        q2.protocol = "second"
+        assert [r.protocol for r in rank_bridge_quotes([q1, q2])] == ["first", "second"]
+
+    def test_empty_input_returns_empty_list(self):
+        assert rank_bridge_quotes([]) == []
+
+
+class TestBridgeRouter:
+    def test_requires_at_least_one_bridge(self):
+        with pytest.raises(ValueError):
+            BridgeRouter([])
+
+    @pytest.mark.asyncio
+    async def test_quote_all_calls_every_bridge(self):
+        b1 = _mock_bridge(quote=_legacy_quote(amount_out=99_800_000, fee=200_000))
+        b2 = _mock_bridge(quote=_ccip_native_quote(amount_in=100_000_000, native_fee=10**15))
+        quotes = await BridgeRouter([b1, b2]).quote_all(USDC_ETH, USDC_ARB, _ROUTER_AMOUNT)
+        assert len(quotes) == 2
+        b1.get_quote.assert_called_once_with(USDC_ETH, USDC_ARB, _ROUTER_AMOUNT)
+        b2.get_quote.assert_called_once_with(USDC_ETH, USDC_ARB, _ROUTER_AMOUNT)
+
+    @pytest.mark.asyncio
+    async def test_quote_all_skips_bridge_errors(self):
+        """BridgeError from a single bridge does not poison the whole batch."""
+        good = _mock_bridge(quote=_legacy_quote(amount_out=99_800_000, fee=200_000))
+        bad = _mock_bridge(side_effect=BridgeError("lane unsupported"))
+        quotes = await BridgeRouter([bad, good]).quote_all(USDC_ETH, USDC_ARB, _ROUTER_AMOUNT)
+        assert [q.protocol for q in quotes] == ["CCTP"]
+
+    @pytest.mark.asyncio
+    async def test_quote_all_propagates_other_exceptions(self):
+        """Non-BridgeError exceptions bubble up to the caller."""
+        bad = _mock_bridge(side_effect=RuntimeError("boom"))
+        with pytest.raises(RuntimeError, match="boom"):
+            await BridgeRouter([bad]).quote_all(USDC_ETH, USDC_ARB, _ROUTER_AMOUNT)

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -1455,10 +1455,10 @@ class TestRankBridgeQuotes:
         assert ranked[0].effective_amount_out > ranked[1].effective_amount_out
 
     def test_unrankable_quotes_keep_input_order(self):
-        """Unrankable quotes preserve insertion order (stable sort)."""
-        q1 = _ccip_native_quote(amount_in=100_000_000, native_fee=10**15)
+        """Unrankable quotes preserve insertion order regardless of amount_out."""
+        q1 = _ccip_native_quote(amount_in=50_000_000, native_fee=10**15)
         q1.protocol = "first"
-        q2 = _ccip_native_quote(amount_in=100_000_000, native_fee=10**15)
+        q2 = _ccip_native_quote(amount_in=200_000_000, native_fee=10**15)
         q2.protocol = "second"
         assert [r.protocol for r in rank_bridge_quotes([q1, q2])] == ["first", "second"]
 


### PR DESCRIPTION
- `CCIP` wraps the per-chain Router with token-only `ccipSend`, on-chain `getFee` quotes, native + ERC-20 fee paths, EVMExtraArgsV2 encoding, and per-chain Router / chain-selector registries.
- `CCIPComposer.sol` receives tokens on the destination chain, prepends a DeFiVM prologue `(amountReceived, sourceChainSelector)`, and forwards execution to DeFiVM; `CCIP.build_bridge_compose_tx` carries a DeFiVM program as the message data and targets the composer. Hardened with: - required `_allowlistEnabled` constructor arg (explicit fail-open vs fail-closed choice at deploy) - opt-in `(sourceChainSelector, sender)` allowlist with admin setters and events - zero-address constructor guards on `_router` / `_vm` / `_owner` - validated `fee_token_decimals` (range `[0, 36]`, rejects `bool` / `float`)
- `BridgeRouter` fans `get_quote` across bridges in parallel; the free function `rank_bridge_quotes` orders the quotes by effective amount delivered, routing CCIP's separate fee-token cost through a caller-supplied `FeeConverter`.
  
Closes https://github.com/yihuang/pydefi/issues/143