### PR TITLE
Problem: Lucid adapter discovery rescans logs on non-archive node

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,6 +40,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          token: ${{ secrets.PAT }}
           fetch-depth: 0
 
       - name: Set up Python 3.12
@@ -62,6 +63,7 @@ jobs:
         with:
           commit_message: "style: auto-fix ruff format and lint"
           branch: ${{ github.head_ref }}
+          token: ${{ secrets.PAT }}
 
   lint:
     runs-on: ubuntu-latest

--- a/pydefi/deployments.py
+++ b/pydefi/deployments.py
@@ -129,9 +129,12 @@ _CONTRACTS: dict[str, dict[int, str]] = {
         ChainId.MANTRA: "0x0569725992ee675f862bf0d25CA40fCfB2B69d6E",
         ChainId.KITE: "0xc620C68Cb63EA35e9930e240051A6A7C02D568A1",
     },
-    # Adapter addresses are not published by Lucid; discover via TransferRelayed
-    # event scan against any controller, then pass to LucidBridge(adapter_address=…).
+    # Lucid adapters aren't published (factory-deployed); pinned here from a
+    # one-time TransferRelayed scan to avoid re-scan on every run.
+    # https://kitescan.ai/address/0x5ef37628D45C80740Fb6Db7Ed9C0A753B4f85263
     "LUCID_LAYERZERO_ADAPTER": {ChainId.KITE: "0x5ef37628D45C80740Fb6Db7Ed9C0A753B4f85263"},
+    # https://blockscout.mantrascan.io/address/0xA9bD5559531fe372E866AD4337599962d5810E01
+    "LUCID_HYPERLANE_ADAPTER": {ChainId.MANTRA: "0xA9bD5559531fe372E866AD4337599962d5810E01"},
 }
 
 

--- a/tests/live/test_lucid_live.py
+++ b/tests/live/test_lucid_live.py
@@ -17,7 +17,7 @@ import pytest
 from web3 import AsyncWeb3
 
 from pydefi.abi.bridge import LUCID_ASSET_CONTROLLER
-from pydefi.bridge.lucid import LucidBridge, discover_adapter
+from pydefi.bridge.lucid import LucidBridge
 from pydefi.deployments import get_address, get_token
 from pydefi.rpc import get_w3
 from pydefi.types import Address, ChainId, TokenAmount
@@ -51,12 +51,14 @@ def _ctrl_addr(name: str, src_chain_id: int) -> Address:
     return Address(bytes.fromhex(get_address(name, src_chain_id)[2:]))
 
 
-async def _adapter_addr(src_chain_id: int, w3: AsyncWeb3, controller: Address) -> Address:
-    # Kite has the LZ adapter pinned in deployments.py; MANTRA's Hyperlane
-    # adapter isn't published, so discover it from on-chain events.
-    if src_chain_id == ChainId.KITE:
-        return Address(bytes.fromhex(get_address("LUCID_LAYERZERO_ADAPTER", src_chain_id)[2:]))
-    return await discover_adapter(w3, controller)
+_ADAPTER_BY_SRC = {
+    ChainId.KITE: "LUCID_LAYERZERO_ADAPTER",
+    ChainId.MANTRA: "LUCID_HYPERLANE_ADAPTER",
+}
+
+
+def _adapter_addr(src_chain_id: int) -> Address:
+    return Address(bytes.fromhex(get_address(_ADAPTER_BY_SRC[src_chain_id], src_chain_id)[2:]))
 
 
 def _all_controllers() -> list[tuple[int, str]]:
@@ -107,14 +109,12 @@ class TestLucidBridgeLive:
     """End-to-end exercise of ``LucidBridge`` against live contracts on each source."""
 
     async def _client(self, src_chain_id: int, w3: AsyncWeb3, controller_name: str) -> LucidBridge:
-        ctrl = _ctrl_addr(controller_name, src_chain_id)
-        adapter = await _adapter_addr(src_chain_id, w3, ctrl)
         return LucidBridge(
             w3=w3,
             src_chain_id=src_chain_id,
             dst_chain_id=_LANES[src_chain_id][controller_name][1],
-            controller_address=ctrl,
-            adapter_address=adapter,
+            controller_address=_ctrl_addr(controller_name, src_chain_id),
+            adapter_address=_adapter_addr(src_chain_id),
         )
 
     async def test_quote_native_fee_positive_usdc(self, src):


### PR DESCRIPTION
to avoid flaky on `failed to fetch block result from CometBFT` [error](https://github.com/yihuang/pydefi/actions/runs/26445277047/job/77849872330)
