### PR TITLE
Problem: code is duplicated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ htmlcov/
 
 /.env
 /.envrc
+/.direnv

--- a/pydefi/__init__.py
+++ b/pydefi/__init__.py
@@ -57,7 +57,13 @@ from pydefi.exceptions import (
     PydefiError,
     SlippageExceededError,
 )
-from pydefi.pathfinder.dag import RouteDAG
+from pydefi.pathfinder.dag import (
+    RouteBridge,
+    RouteDAG,
+    RouteSplit,
+    RouteSplitLeg,
+    RouteSwap,
+)
 from pydefi.pool_data.base import PoolData
 from pydefi.rpc import MultiRpcProvider, fetch_chain_rpcs, get_w3
 from pydefi.types import (
@@ -65,16 +71,12 @@ from pydefi.types import (
     BridgeQuote,
     ChainId,
     Hash,
-    RouteBridge,
-    RouteSplit,
-    RouteSplitLeg,
-    RouteSwap,
     SwapRoute,
     SwapStep,
-    SwapTransaction,
     Token,
     TokenAmount,
 )
+from pydefi.vm.swap import SwapTransaction
 
 __version__ = "0.1.0"
 

--- a/pydefi/_utils.py
+++ b/pydefi/_utils.py
@@ -121,17 +121,14 @@ def resolve_amount(amount: TokenAmount | tuple[Token, Literal["max"]]) -> tuple[
     """Accept either an exact :class:`TokenAmount` or ``(token, "max")``."""
     if isinstance(amount, TokenAmount):
         return amount.token, amount.amount
-    if isinstance(amount, tuple) and len(amount) == 2 and amount[1] == "max":
-        return amount[0], UINT256_MAX
-    raise TypeError("amount must be a TokenAmount or (Token, 'max') tuple")
+    return amount[0], UINT256_MAX
 
 
-def to_tx(to: Address, call_data: bytes, **kwargs: Any) -> dict[str, Any]:
+def to_tx(to: Address, data: bytes, **kwargs: Any) -> dict[str, Any]:
     """Format a calldata payload as the project-wide tx dict shape."""
-    value = kwargs.pop("value", "0")
+    kwargs.setdefault("value", "0")
     return {
         "to": to.to_0x_hex(),
-        "data": "0x" + call_data.hex(),
-        "value": value,
+        "data": "0x" + data.hex(),
         **kwargs,
     }

--- a/pydefi/_utils.py
+++ b/pydefi/_utils.py
@@ -126,10 +126,12 @@ def resolve_amount(amount: TokenAmount | tuple[Token, Literal["max"]]) -> tuple[
     raise TypeError("amount must be a TokenAmount or (Token, 'max') tuple")
 
 
-def to_tx(to: Address, call_data: bytes, **kwargs) -> dict[str, Any]:
+def to_tx(to: Address, call_data: bytes, **kwargs: Any) -> dict[str, Any]:
     """Format a calldata payload as the project-wide tx dict shape."""
+    value = kwargs.pop("value", "0")
     return {
         "to": to.to_0x_hex(),
         "data": "0x" + call_data.hex(),
+        "value": value,
         **kwargs,
     }

--- a/pydefi/_utils.py
+++ b/pydefi/_utils.py
@@ -20,10 +20,15 @@ are handled correctly.
 
 from __future__ import annotations
 
+from typing import Any, Literal
+
 import base58
 from hexbytes import HexBytes
 
-from pydefi.types import NATIVE_ADDRESSES, ZERO_HASH, Address, ChainId, Hash
+from pydefi.types import NATIVE_ADDRESSES, ZERO_HASH, Address, ChainId, Hash, Token, TokenAmount
+
+#: ``type(uint256).max``
+UINT256_MAX: int = (1 << 256) - 1
 
 
 def address_to_bytes32(address: Address) -> Hash:
@@ -110,3 +115,21 @@ def decode_address(addr_str: str, chain_id: int) -> Address:
         if len(bz) != 20:
             raise ValueError(f"Invalid EVM address: {addr_str!r}")
     return Address(bz)
+
+
+def resolve_amount(amount: TokenAmount | tuple[Token, Literal["max"]]) -> tuple[Token, int]:
+    """Accept either an exact :class:`TokenAmount` or ``(token, "max")``."""
+    if isinstance(amount, TokenAmount):
+        return amount.token, amount.amount
+    if isinstance(amount, tuple) and len(amount) == 2 and amount[1] == "max":
+        return amount[0], UINT256_MAX
+    raise TypeError("amount must be a TokenAmount or (Token, 'max') tuple")
+
+
+def to_tx(to: Address, call_data: bytes, **kwargs) -> dict[str, Any]:
+    """Format a calldata payload as the project-wide tx dict shape."""
+    return {
+        "to": to.to_0x_hex(),
+        "data": "0x" + call_data.hex(),
+        **kwargs,
+    }

--- a/pydefi/_utils.py
+++ b/pydefi/_utils.py
@@ -121,7 +121,9 @@ def resolve_amount(amount: TokenAmount | tuple[Token, Literal["max"]]) -> tuple[
     """Accept either an exact :class:`TokenAmount` or ``(token, "max")``."""
     if isinstance(amount, TokenAmount):
         return amount.token, amount.amount
-    return amount[0], UINT256_MAX
+    if isinstance(amount, tuple) and len(amount) == 2 and amount[1] == "max":
+        return amount[0], UINT256_MAX
+    raise TypeError("amount must be a TokenAmount or (Token, 'max') tuple")
 
 
 def to_tx(to: Address, data: bytes, **kwargs: Any) -> dict[str, Any]:

--- a/pydefi/aggregator/base.py
+++ b/pydefi/aggregator/base.py
@@ -48,7 +48,7 @@ class AggregatorQuote:
         step = SwapStep(
             token_in=self.token_in,
             token_out=self.token_out,
-            pool_address=pool_address if pool_address is not None else None,
+            pool_address=pool_address,
             protocol=self.protocol,
             fee=0,
         )

--- a/pydefi/aggregator/base.py
+++ b/pydefi/aggregator/base.py
@@ -6,7 +6,8 @@ from dataclasses import dataclass, field
 from decimal import Decimal
 from typing import Any
 
-from pydefi.types import Token, TokenAmount
+from pydefi._math import apply_slippage
+from pydefi.types import Address, SwapRoute, SwapStep, Token, TokenAmount
 
 
 @dataclass
@@ -36,3 +37,58 @@ class AggregatorQuote:
     tx_data: dict[str, Any] = field(default_factory=dict)
     protocol: str = ""
     route_summary: str = ""
+
+    def to_swap_route(self, *, pool_address: Address | None = None) -> SwapRoute:
+        """Build a single-hop :class:`~pydefi.types.SwapRoute` from this quote.
+
+        Args:
+            pool_address: Address of the pool or router contract.  ``None`` for
+                aggregator quotes where the individual pool is unknown.
+        """
+        step = SwapStep(
+            token_in=self.token_in,
+            token_out=self.token_out,
+            pool_address=pool_address if pool_address is not None else None,
+            protocol=self.protocol,
+            fee=0,
+        )
+        return SwapRoute(
+            steps=[step],
+            amount_in=self.amount_in,
+            amount_out=self.amount_out,
+            price_impact=self.price_impact,
+        )
+
+    @classmethod
+    def from_quote(
+        cls,
+        *,
+        token_in: Token,
+        token_out: Token,
+        amount_in: TokenAmount,
+        amount_out_raw: int,
+        slippage_bps: int,
+        gas_estimate: int = 0,
+        price_impact: Decimal = Decimal(0),
+        protocol: str = "",
+        route_summary: str = "",
+        tx_data: dict[str, Any] | None = None,
+    ) -> AggregatorQuote:
+        """Construct an :class:`AggregatorQuote` from raw quote fields.
+
+        ``min_amount_out`` is computed from *amount_out_raw* via
+        :func:`~pydefi._math.apply_slippage`.
+        """
+        min_out = apply_slippage(amount_out_raw, slippage_bps)
+        return cls(
+            token_in=token_in,
+            token_out=token_out,
+            amount_in=amount_in,
+            amount_out=TokenAmount(token=token_out, amount=amount_out_raw),
+            min_amount_out=TokenAmount(token=token_out, amount=min_out),
+            gas_estimate=gas_estimate,
+            price_impact=price_impact,
+            tx_data=tx_data or {},
+            protocol=protocol,
+            route_summary=route_summary,
+        )

--- a/pydefi/aggregator/jupiter.py
+++ b/pydefi/aggregator/jupiter.py
@@ -28,7 +28,7 @@ import aiohttp
 
 from pydefi.aggregator.base import AggregatorQuote
 from pydefi.exceptions import AggregatorError
-from pydefi.types import ChainId, SwapRoute, SwapStep, Token, TokenAmount
+from pydefi.types import ChainId, SwapRoute, Token, TokenAmount
 
 _JUPITER_API_BASE = "https://lite-api.jup.ag/swap/v1"
 _JUPITER_SWAP_V2_BASE = "https://api.jup.ag/swap/v2"
@@ -61,9 +61,7 @@ class Jupiter:
     def base_url(self) -> str:
         return self._base_url
 
-    @property
-    def protocol_name(self) -> str:
-        return "Jupiter"
+    protocol_name: str = "Jupiter"
 
     def _headers(self) -> dict[str, str]:
         headers: dict[str, str] = {"Accept": "application/json"}
@@ -197,34 +195,9 @@ class Jupiter:
         slippage_bps: int = 50,
         **kwargs: Any,
     ) -> SwapRoute:
-        """Build a :class:`~pydefi.types.SwapRoute` from a Jupiter quote.
-
-        Args:
-            amount_in: Exact input amount.
-            token_out: Desired output token.
-            slippage_bps: Maximum acceptable slippage in basis points.
-            **kwargs: Extra query parameters forwarded to :meth:`get_quote`.
-
-        Returns:
-            A :class:`~pydefi.types.SwapRoute` with a single
-            :class:`~pydefi.types.SwapStep` (Jupiter aggregates internally).
-        """
+        """Build a :class:`~pydefi.types.SwapRoute` from a Jupiter quote."""
         quote = await self.get_quote(amount_in, token_out, slippage_bps, **kwargs)
-
-        step = SwapStep(
-            token_in=amount_in.token,
-            token_out=token_out,
-            pool_address=None,  # Jupiter routes across multiple pools internally
-            protocol=self.protocol_name,
-            fee=0,
-        )
-
-        return SwapRoute(
-            steps=[step],
-            amount_in=amount_in,
-            amount_out=quote.amount_out,
-            price_impact=quote.price_impact,
-        )
+        return quote.to_swap_route()
 
 
 class JupiterSwapV2:
@@ -269,9 +242,7 @@ class JupiterSwapV2:
     def base_url(self) -> str:
         return self._base_url
 
-    @property
-    def protocol_name(self) -> str:
-        return "Jupiter"
+    protocol_name: str = "Jupiter"
 
     def _headers(self) -> dict[str, str]:
         headers: dict[str, str] = {"Accept": "application/json"}
@@ -480,31 +451,6 @@ class JupiterSwapV2:
         slippage_bps: int = 50,
         **kwargs: Any,
     ) -> SwapRoute:
-        """Build a :class:`~pydefi.types.SwapRoute` from a Swap V2 quote.
-
-        Args:
-            amount_in: Exact input amount.
-            token_out: Desired output token.
-            slippage_bps: Maximum acceptable slippage in basis points.
-            **kwargs: Extra query parameters forwarded to :meth:`get_quote`.
-
-        Returns:
-            A :class:`~pydefi.types.SwapRoute` with a single
-            :class:`~pydefi.types.SwapStep` (Jupiter aggregates internally).
-        """
+        """Build a :class:`~pydefi.types.SwapRoute` from a Swap V2 quote."""
         quote = await self.get_quote(amount_in, token_out, slippage_bps, **kwargs)
-
-        step = SwapStep(
-            token_in=amount_in.token,
-            token_out=token_out,
-            pool_address=None,  # Jupiter routes across multiple pools internally
-            protocol=self.protocol_name,
-            fee=0,
-        )
-
-        return SwapRoute(
-            steps=[step],
-            amount_in=amount_in,
-            amount_out=quote.amount_out,
-            price_impact=quote.price_impact,
-        )
+        return quote.to_swap_route()

--- a/pydefi/aggregator/okx.py
+++ b/pydefi/aggregator/okx.py
@@ -11,10 +11,10 @@ from typing import Any
 
 import aiohttp
 
-from pydefi._math import apply_slippage, slippage_to_percent
+from pydefi._math import slippage_to_percent
 from pydefi.aggregator.base import AggregatorQuote
 from pydefi.exceptions import AggregatorError
-from pydefi.types import SwapRoute, SwapStep, Token, TokenAmount
+from pydefi.types import SwapRoute, Token, TokenAmount
 
 
 class OKX:
@@ -42,9 +42,7 @@ class OKX:
     def base_url(self) -> str:
         return self._base_url
 
-    @property
-    def protocol_name(self) -> str:
-        return "OKX"
+    protocol_name: str = "OKX"
 
     def _headers(self) -> dict[str, str]:
         headers: dict[str, str] = {"Content-Type": "application/json"}
@@ -95,15 +93,14 @@ class OKX:
         result = data["data"]
 
         to_amount = int(result["toTokenAmount"])
-        min_amount_out_raw = apply_slippage(to_amount, slippage_bps)
         gas_estimate = int(result.get("estimateGasFee", 0))
 
-        return AggregatorQuote(
+        return AggregatorQuote.from_quote(
             token_in=amount_in.token,
             token_out=token_out,
             amount_in=amount_in,
-            amount_out=TokenAmount(token=token_out, amount=to_amount),
-            min_amount_out=TokenAmount(token=token_out, amount=min_amount_out_raw),
+            amount_out_raw=to_amount,
+            slippage_bps=slippage_bps,
             gas_estimate=gas_estimate,
             price_impact=Decimal(str(result.get("priceImpactPercentage", "0"))),
             protocol=self.protocol_name,
@@ -144,7 +141,6 @@ class OKX:
         result = data["data"]
 
         to_amount = int(result["routerResult"]["toTokenAmount"])
-        min_amount_out_raw = apply_slippage(to_amount, slippage_bps)
 
         tx_info = result.get("tx", {})
         gas_estimate = int(tx_info.get("gas", result.get("estimateGasFee", 0)))
@@ -157,12 +153,12 @@ class OKX:
             "gasPrice": tx_info.get("gasPrice", ""),
         }
 
-        return AggregatorQuote(
+        return AggregatorQuote.from_quote(
             token_in=amount_in.token,
             token_out=token_out,
             amount_in=amount_in,
-            amount_out=TokenAmount(token=token_out, amount=to_amount),
-            min_amount_out=TokenAmount(token=token_out, amount=min_amount_out_raw),
+            amount_out_raw=to_amount,
+            slippage_bps=slippage_bps,
             gas_estimate=gas_estimate,
             price_impact=Decimal(str(result.get("priceImpactPercentage", "0"))),
             tx_data=tx_data,
@@ -177,29 +173,6 @@ class OKX:
         slippage_bps: int = 50,
         **kwargs: Any,
     ) -> SwapRoute:
-        """Build a :class:`~pydefi.types.SwapRoute` from an OKX DEX quote.
-
-        Args:
-            amount_in: Exact input amount.
-            token_out: Desired output token.
-            slippage_bps: Maximum slippage in basis points.
-
-        Returns:
-            A :class:`~pydefi.types.SwapRoute`.
-        """
+        """Build a :class:`~pydefi.types.SwapRoute` from an OKX DEX quote."""
         quote = await self.get_quote(amount_in, token_out, slippage_bps, **kwargs)
-
-        step = SwapStep(
-            token_in=amount_in.token,
-            token_out=token_out,
-            pool_address=None,
-            protocol=self.protocol_name,
-            fee=0,
-        )
-
-        return SwapRoute(
-            steps=[step],
-            amount_in=amount_in,
-            amount_out=quote.amount_out,
-            price_impact=quote.price_impact,
-        )
+        return quote.to_swap_route()

--- a/pydefi/aggregator/okx_router_encoder.py
+++ b/pydefi/aggregator/okx_router_encoder.py
@@ -62,8 +62,8 @@ from __future__ import annotations
 from pydefi import Token
 from pydefi._math import MAX_BPS
 from pydefi.abi.dex_aggregator import OKX_DEX_ROUTER, BaseRequest, RouterPath
-from pydefi.pathfinder.dag import RouteDAG
-from pydefi.types import Address, RouteAction, RouteSplit, RouteSwap, SwapProtocol
+from pydefi.pathfinder.dag import RouteAction, RouteDAG, RouteSplit, RouteSwap
+from pydefi.types import Address, SwapProtocol
 
 # ---------------------------------------------------------------------------
 # DexRouter bit-mask constants (from CommonUtils.sol)

--- a/pydefi/aggregator/oneinch.py
+++ b/pydefi/aggregator/oneinch.py
@@ -11,10 +11,10 @@ from typing import Any
 
 import aiohttp
 
-from pydefi._math import apply_slippage, slippage_to_percent
+from pydefi._math import slippage_to_percent
 from pydefi.aggregator.base import AggregatorQuote
 from pydefi.exceptions import AggregatorError
-from pydefi.types import SwapRoute, SwapStep, Token, TokenAmount
+from pydefi.types import SwapRoute, Token, TokenAmount
 
 
 class OneInch:
@@ -42,9 +42,7 @@ class OneInch:
     def base_url(self) -> str:
         return self._base_url
 
-    @property
-    def protocol_name(self) -> str:
-        return "1inch"
+    protocol_name: str = "1inch"
 
     def _headers(self) -> dict[str, str]:
         headers: dict[str, str] = {"Accept": "application/json"}
@@ -94,14 +92,13 @@ class OneInch:
         data = await self._get("quote", params)
 
         dst_amount = int(data["dstAmount"])
-        min_amount_out_raw = apply_slippage(dst_amount, slippage_bps)
 
-        return AggregatorQuote(
+        return AggregatorQuote.from_quote(
             token_in=amount_in.token,
             token_out=token_out,
             amount_in=amount_in,
-            amount_out=TokenAmount(token=token_out, amount=dst_amount),
-            min_amount_out=TokenAmount(token=token_out, amount=min_amount_out_raw),
+            amount_out_raw=dst_amount,
+            slippage_bps=slippage_bps,
             gas_estimate=int(data.get("gas", 0)),
             price_impact=Decimal(str(data.get("estimatedPriceImpact", "0"))),
             protocol=self.protocol_name,
@@ -141,16 +138,14 @@ class OneInch:
 
         tx = data.get("tx", {})
         dst_amount = int(data["dstAmount"])
-        min_amount_out_raw = apply_slippage(dst_amount, slippage_bps)
 
-        return AggregatorQuote(
+        return AggregatorQuote.from_quote(
             token_in=amount_in.token,
             token_out=token_out,
             amount_in=amount_in,
-            amount_out=TokenAmount(token=token_out, amount=dst_amount),
-            min_amount_out=TokenAmount(token=token_out, amount=min_amount_out_raw),
+            amount_out_raw=dst_amount,
+            slippage_bps=slippage_bps,
             gas_estimate=int(tx.get("gas", data.get("gas", 0))),
-            price_impact=Decimal(0),
             tx_data=tx,
             protocol=self.protocol_name,
             route_summary=str(data.get("protocols", "")),
@@ -163,29 +158,6 @@ class OneInch:
         slippage_bps: int = 50,
         **kwargs: Any,
     ) -> SwapRoute:
-        """Build a :class:`~pydefi.types.SwapRoute` from a 1inch quote.
-
-        Args:
-            amount_in: Exact input amount.
-            token_out: Desired output token.
-            slippage_bps: Maximum slippage in basis points.
-
-        Returns:
-            A :class:`~pydefi.types.SwapRoute`.
-        """
+        """Build a :class:`~pydefi.types.SwapRoute` from a 1inch quote."""
         quote = await self.get_quote(amount_in, token_out, slippage_bps, **kwargs)
-
-        step = SwapStep(
-            token_in=amount_in.token,
-            token_out=token_out,
-            pool_address=None,  # 1inch routes through multiple pools
-            protocol=self.protocol_name,
-            fee=0,
-        )
-
-        return SwapRoute(
-            steps=[step],
-            amount_in=amount_in,
-            amount_out=quote.amount_out,
-            price_impact=quote.price_impact,
-        )
+        return quote.to_swap_route()

--- a/pydefi/aggregator/openocean.py
+++ b/pydefi/aggregator/openocean.py
@@ -11,11 +11,12 @@ from typing import Any
 
 import aiohttp
 
-from pydefi._math import apply_slippage, slippage_to_percent
+from pydefi import Address
+from pydefi._math import slippage_to_percent
 from pydefi._utils import encode_address
 from pydefi.aggregator.base import AggregatorQuote
 from pydefi.exceptions import AggregatorError
-from pydefi.types import Address, SwapRoute, SwapStep, Token, TokenAmount
+from pydefi.types import SwapRoute, Token, TokenAmount
 
 # Mapping from EVM chain IDs to OpenOcean chain slugs
 _CHAIN_SLUGS: dict[int, str] = {
@@ -71,9 +72,7 @@ class OpenOcean:
     def base_url(self) -> str:
         return self._base_url
 
-    @property
-    def protocol_name(self) -> str:
-        return "OpenOcean"
+    protocol_name: str = "OpenOcean"
 
     @property
     def chain_slug(self) -> str:
@@ -148,15 +147,14 @@ class OpenOcean:
         result = data["data"]
 
         out_amount = int(result["outAmount"])
-        min_amount_out_raw = apply_slippage(out_amount, slippage_bps)
         gas_estimate = int(result.get("estimatedGas", 0))
 
-        return AggregatorQuote(
+        return AggregatorQuote.from_quote(
             token_in=amount_in.token,
             token_out=token_out,
             amount_in=amount_in,
-            amount_out=TokenAmount(token=token_out, amount=out_amount),
-            min_amount_out=TokenAmount(token=token_out, amount=min_amount_out_raw),
+            amount_out_raw=out_amount,
+            slippage_bps=slippage_bps,
             gas_estimate=gas_estimate,
             price_impact=_parse_price_impact(result.get("price_impact")),
             protocol=self.protocol_name,
@@ -203,7 +201,6 @@ class OpenOcean:
         result = data["data"]
 
         out_amount = int(result["outAmount"])
-        min_amount_out_raw = apply_slippage(out_amount, slippage_bps)
 
         gas_estimate = int(result.get("estimatedGas", 0))
         tx_info = result
@@ -215,12 +212,12 @@ class OpenOcean:
             "gasPrice": tx_info.get("gasPrice", ""),
         }
 
-        return AggregatorQuote(
+        return AggregatorQuote.from_quote(
             token_in=amount_in.token,
             token_out=token_out,
             amount_in=amount_in,
-            amount_out=TokenAmount(token=token_out, amount=out_amount),
-            min_amount_out=TokenAmount(token=token_out, amount=min_amount_out_raw),
+            amount_out_raw=out_amount,
+            slippage_bps=slippage_bps,
             gas_estimate=gas_estimate,
             price_impact=_parse_price_impact(result.get("price_impact")),
             tx_data=tx_data,
@@ -235,29 +232,6 @@ class OpenOcean:
         slippage_bps: int = 50,
         **kwargs: Any,
     ) -> SwapRoute:
-        """Build a :class:`~pydefi.types.SwapRoute` from an OpenOcean quote.
-
-        Args:
-            amount_in: Exact input amount.
-            token_out: Desired output token.
-            slippage_bps: Maximum slippage in basis points.
-
-        Returns:
-            A :class:`~pydefi.types.SwapRoute`.
-        """
+        """Build a :class:`~pydefi.types.SwapRoute` from an OpenOcean quote."""
         quote = await self.get_quote(amount_in, token_out, slippage_bps, **kwargs)
-
-        step = SwapStep(
-            token_in=amount_in.token,
-            token_out=token_out,
-            pool_address=None,
-            protocol=self.protocol_name,
-            fee=0,
-        )
-
-        return SwapRoute(
-            steps=[step],
-            amount_in=amount_in,
-            amount_out=quote.amount_out,
-            price_impact=quote.price_impact,
-        )
+        return quote.to_swap_route()

--- a/pydefi/aggregator/openocean.py
+++ b/pydefi/aggregator/openocean.py
@@ -11,12 +11,11 @@ from typing import Any
 
 import aiohttp
 
-from pydefi import Address
 from pydefi._math import slippage_to_percent
 from pydefi._utils import encode_address
 from pydefi.aggregator.base import AggregatorQuote
 from pydefi.exceptions import AggregatorError
-from pydefi.types import SwapRoute, Token, TokenAmount
+from pydefi.types import Address, SwapRoute, Token, TokenAmount
 
 # Mapping from EVM chain IDs to OpenOcean chain slugs
 _CHAIN_SLUGS: dict[int, str] = {

--- a/pydefi/aggregator/paraswap.py
+++ b/pydefi/aggregator/paraswap.py
@@ -14,7 +14,7 @@ import aiohttp
 from pydefi._math import apply_slippage
 from pydefi.aggregator.base import AggregatorQuote
 from pydefi.exceptions import AggregatorError
-from pydefi.types import SwapRoute, SwapStep, Token, TokenAmount
+from pydefi.types import SwapRoute, Token, TokenAmount
 
 
 class ParaSwap:
@@ -42,9 +42,7 @@ class ParaSwap:
     def base_url(self) -> str:
         return self._base_url
 
-    @property
-    def protocol_name(self) -> str:
-        return "ParaSwap"
+    protocol_name: str = "ParaSwap"
 
     def _headers(self) -> dict[str, str]:
         headers: dict[str, str] = {"Accept": "application/json"}
@@ -123,16 +121,15 @@ class ParaSwap:
         price_route = data.get("priceRoute", {})
 
         dest_amount = int(price_route.get("destAmount", 0))
-        min_amount_out_raw = apply_slippage(dest_amount, slippage_bps)
         gas_cost = int(price_route.get("gasCost", 0))
         price_impact_raw = price_route.get("percentChange", "0")
 
-        return AggregatorQuote(
+        return AggregatorQuote.from_quote(
             token_in=amount_in.token,
             token_out=token_out,
             amount_in=amount_in,
-            amount_out=TokenAmount(token=token_out, amount=dest_amount),
-            min_amount_out=TokenAmount(token=token_out, amount=min_amount_out_raw),
+            amount_out_raw=dest_amount,
+            slippage_bps=slippage_bps,
             gas_estimate=gas_cost,
             price_impact=Decimal(str(price_impact_raw)),
             protocol=self.protocol_name,
@@ -181,12 +178,12 @@ class ParaSwap:
         }
         tx_data = await self._post(f"transactions/{self.chain_id}", body)
 
-        return AggregatorQuote(
+        return AggregatorQuote.from_quote(
             token_in=amount_in.token,
             token_out=token_out,
             amount_in=amount_in,
-            amount_out=TokenAmount(token=token_out, amount=dest_amount),
-            min_amount_out=TokenAmount(token=token_out, amount=min_amount_out_raw),
+            amount_out_raw=dest_amount,
+            slippage_bps=slippage_bps,
             gas_estimate=int(tx_data.get("gas", 0)),
             price_impact=Decimal(str(price_route.get("percentChange", "0"))),
             tx_data=tx_data,
@@ -200,29 +197,6 @@ class ParaSwap:
         slippage_bps: int = 50,
         **kwargs: Any,
     ) -> SwapRoute:
-        """Build a :class:`~pydefi.types.SwapRoute` from a ParaSwap quote.
-
-        Args:
-            amount_in: Exact input amount.
-            token_out: Desired output token.
-            slippage_bps: Maximum slippage in basis points.
-
-        Returns:
-            A :class:`~pydefi.types.SwapRoute`.
-        """
+        """Build a :class:`~pydefi.types.SwapRoute` from a ParaSwap quote."""
         quote = await self.get_quote(amount_in, token_out, slippage_bps, **kwargs)
-
-        step = SwapStep(
-            token_in=amount_in.token,
-            token_out=token_out,
-            pool_address=None,
-            protocol=self.protocol_name,
-            fee=0,
-        )
-
-        return SwapRoute(
-            steps=[step],
-            amount_in=amount_in,
-            amount_out=quote.amount_out,
-            price_impact=quote.price_impact,
-        )
+        return quote.to_swap_route()

--- a/pydefi/aggregator/uniswap.py
+++ b/pydefi/aggregator/uniswap.py
@@ -15,7 +15,7 @@ from pydefi._math import apply_slippage, slippage_to_percent
 from pydefi._utils import encode_address
 from pydefi.aggregator.base import AggregatorQuote
 from pydefi.exceptions import AggregatorError
-from pydefi.types import Address, SwapRoute, SwapStep, Token, TokenAmount
+from pydefi.types import Address, SwapRoute, Token, TokenAmount
 
 # Routing types returned by /v1/quote that are compatible with POST /v1/swap.
 # UniswapX types (DUTCH_V2, DUTCH_V3, PRIORITY) must use POST /v1/order instead.
@@ -57,9 +57,7 @@ class UniswapAPI:
     def base_url(self) -> str:
         return self._base_url
 
-    @property
-    def protocol_name(self) -> str:
-        return "Uniswap"
+    protocol_name: str = "Uniswap"
 
     def _headers(self) -> dict[str, str]:
         headers: dict[str, str] = {
@@ -313,29 +311,6 @@ class UniswapAPI:
         slippage_bps: int = 50,
         **kwargs: Any,
     ) -> SwapRoute:
-        """Build a :class:`~pydefi.types.SwapRoute` from a Uniswap quote.
-
-        Args:
-            amount_in: Exact input amount.
-            token_out: Desired output token.
-            slippage_bps: Maximum slippage in basis points.
-
-        Returns:
-            A :class:`~pydefi.types.SwapRoute`.
-        """
+        """Build a :class:`~pydefi.types.SwapRoute` from a Uniswap quote."""
         quote = await self.get_quote(amount_in, token_out, slippage_bps, **kwargs)
-
-        step = SwapStep(
-            token_in=amount_in.token,
-            token_out=token_out,
-            pool_address=None,  # Uniswap API routes through multiple pools
-            protocol=self.protocol_name,
-            fee=0,
-        )
-
-        return SwapRoute(
-            steps=[step],
-            amount_in=amount_in,
-            amount_out=quote.amount_out,
-            price_impact=quote.price_impact,
-        )
+        return quote.to_swap_route()

--- a/pydefi/aggregator/zerox.py
+++ b/pydefi/aggregator/zerox.py
@@ -11,10 +11,10 @@ from typing import Any
 
 import aiohttp
 
-from pydefi._math import apply_slippage, slippage_to_fraction
+from pydefi._math import slippage_to_fraction
 from pydefi.aggregator.base import AggregatorQuote
 from pydefi.exceptions import AggregatorError
-from pydefi.types import Address, SwapRoute, SwapStep, Token, TokenAmount
+from pydefi.types import Address, SwapRoute, Token, TokenAmount
 
 # Mapping from chain IDs to 0x API subdomain / base URLs
 _CHAIN_URLS: dict[int, str] = {
@@ -53,9 +53,7 @@ class ZeroX:
     def base_url(self) -> str:
         return self._base_url
 
-    @property
-    def protocol_name(self) -> str:
-        return "0x"
+    protocol_name: str = "0x"
 
     def _headers(self) -> dict[str, str]:
         headers: dict[str, str] = {"Content-Type": "application/json"}
@@ -124,7 +122,6 @@ class ZeroX:
         data = await self._get("swap/v1/quote", params)
 
         buy_amount = int(data["buyAmount"])
-        min_amount_out_raw = apply_slippage(buy_amount, slippage_bps)
         gas_estimate = int(data.get("estimatedGas", data.get("gas", 0)))
         price_impact_raw = float(data.get("estimatedPriceImpact", "0"))
 
@@ -136,12 +133,12 @@ class ZeroX:
             "gasPrice": data.get("gasPrice", ""),
         }
 
-        return AggregatorQuote(
+        return AggregatorQuote.from_quote(
             token_in=amount_in.token,
             token_out=token_out,
             amount_in=amount_in,
-            amount_out=TokenAmount(token=token_out, amount=buy_amount),
-            min_amount_out=TokenAmount(token=token_out, amount=min_amount_out_raw),
+            amount_out_raw=buy_amount,
+            slippage_bps=slippage_bps,
             gas_estimate=gas_estimate,
             price_impact=Decimal(str(price_impact_raw)),
             tx_data=tx_data,
@@ -156,29 +153,6 @@ class ZeroX:
         slippage_bps: int = 50,
         **kwargs: Any,
     ) -> SwapRoute:
-        """Build a :class:`~pydefi.types.SwapRoute` from a 0x quote.
-
-        Args:
-            amount_in: Exact input amount.
-            token_out: Desired output token.
-            slippage_bps: Maximum slippage in basis points.
-
-        Returns:
-            A :class:`~pydefi.types.SwapRoute`.
-        """
+        """Build a :class:`~pydefi.types.SwapRoute` from a 0x quote."""
         quote = await self.get_quote(amount_in, token_out, slippage_bps, **kwargs)
-
-        step = SwapStep(
-            token_in=amount_in.token,
-            token_out=token_out,
-            pool_address=Address(quote.tx_data["to"]) if quote.tx_data.get("to") else None,
-            protocol=self.protocol_name,
-            fee=0,
-        )
-
-        return SwapRoute(
-            steps=[step],
-            amount_in=amount_in,
-            amount_out=quote.amount_out,
-            price_impact=quote.price_impact,
-        )
+        return quote.to_swap_route(pool_address=Address(quote.tx_data["to"]) if quote.tx_data.get("to") else None)

--- a/pydefi/amm/curve.py
+++ b/pydefi/amm/curve.py
@@ -47,9 +47,7 @@ class CurvePool:
         self._tokens = tokens
         self._use_underlying = use_underlying
 
-    @property
-    def protocol_name(self) -> str:
-        return "Curve"
+    protocol_name: str = "Curve"
 
     @property
     def tokens(self) -> list[Token]:

--- a/pydefi/amm/raydium.py
+++ b/pydefi/amm/raydium.py
@@ -41,9 +41,7 @@ class Raydium:
     def __init__(self, api_url: str | None = None) -> None:
         self.api_url = api_url or self._DEFAULT_API_URL
 
-    @property
-    def protocol_name(self) -> str:
-        return "Raydium"
+    protocol_name: str = "Raydium"
 
     async def _get(self, endpoint: str, params: dict[str, Any]) -> dict[str, Any]:
         url = f"{self.api_url.rstrip('/')}/{endpoint.lstrip('/')}"

--- a/pydefi/amm/universal_router.py
+++ b/pydefi/amm/universal_router.py
@@ -34,7 +34,8 @@ from eth_abi import encode as abi_encode
 from pydefi.amm.uniswap_v3 import UniswapV3
 from pydefi.amm.v4_pool_key import sort_currencies
 from pydefi.deployments import chains_for, get_address
-from pydefi.types import Address, SwapTransaction, Token, TokenAmount
+from pydefi.types import Address, Token, TokenAmount
+from pydefi.vm.swap import SwapTransaction
 
 #: Chain ID -> newest (>= 2.1.1) UniversalRouter deployment, from the registry
 #: (config/uniswap.json). Only >= 2.1.1 routers decode the minHopPriceX36 V4

--- a/pydefi/bridge/across.py
+++ b/pydefi/bridge/across.py
@@ -56,9 +56,7 @@ class Across:
         self.spoke_pool_address = spoke_pool_address
         self._api_base = api_base_url.rstrip("/")
 
-    @property
-    def protocol_name(self) -> str:
-        return "Across"
+    protocol_name: str = "Across"
 
     async def get_suggested_fees(
         self,

--- a/pydefi/bridge/ccip.py
+++ b/pydefi/bridge/ccip.py
@@ -105,9 +105,7 @@ class CCIP:
         # Resolve eagerly so unsupported destinations fail at construction.
         self.dst_chain_selector = _ccip_chain_selector(dst_chain_id)
 
-    @property
-    def protocol_name(self) -> str:
-        return "CCIP"
+    protocol_name: str = "CCIP"
 
     def _build_message(
         self,

--- a/pydefi/bridge/cctp.py
+++ b/pydefi/bridge/cctp.py
@@ -285,9 +285,7 @@ class CCTP:
 
         self.cctp_forwarder_address = cctp_forwarder_address or _CCTP_FORWARDER[is_mainnet]
 
-    @property
-    def protocol_name(self) -> str:
-        return "CCTP"
+    protocol_name: str = "CCTP"
 
     # -----------------------------------------------------------------------
     # Helpers

--- a/pydefi/bridge/eureka.py
+++ b/pydefi/bridge/eureka.py
@@ -78,7 +78,6 @@ class Eureka:
         self.timeout_seconds = timeout_seconds
         self.estimated_time_seconds = estimated_time_seconds
 
-    protocol_name: str = "Eureka"
 
     async def get_quote(
         self,

--- a/pydefi/bridge/eureka.py
+++ b/pydefi/bridge/eureka.py
@@ -78,7 +78,6 @@ class Eureka:
         self.timeout_seconds = timeout_seconds
         self.estimated_time_seconds = estimated_time_seconds
 
-
     async def get_quote(
         self,
         token_in: Token,

--- a/pydefi/bridge/eureka.py
+++ b/pydefi/bridge/eureka.py
@@ -55,7 +55,7 @@ class Eureka:
     the source chain that points at the destination (e.g. ``"07-tendermint-0"``).
     """
 
-    PROTOCOL = "Eureka"
+    protocol_name: str = "Eureka"
 
     def __init__(
         self,
@@ -78,9 +78,7 @@ class Eureka:
         self.timeout_seconds = timeout_seconds
         self.estimated_time_seconds = estimated_time_seconds
 
-    @property
-    def protocol_name(self) -> str:
-        return self.PROTOCOL
+    protocol_name: str = "Eureka"
 
     async def get_quote(
         self,

--- a/pydefi/bridge/gaszip.py
+++ b/pydefi/bridge/gaszip.py
@@ -65,9 +65,7 @@ class GasZip:
         self.contract_address = contract_address
         self._api_base = api_base_url.rstrip("/")
 
-    @property
-    def protocol_name(self) -> str:
-        return "GasZip"
+    protocol_name: str = "GasZip"
 
     def _check_chain(self, chain_id: int) -> None:
         """Raise :class:`~pydefi.exceptions.BridgeError` for unsupported chains."""

--- a/pydefi/bridge/layerzero_oft.py
+++ b/pydefi/bridge/layerzero_oft.py
@@ -82,9 +82,7 @@ class LayerZeroOFT:
         self.oft_address = oft_address
         self.dst_oft_address = dst_oft_address or oft_address
 
-    @property
-    def protocol_name(self) -> str:
-        return "LayerZeroOFT"
+    protocol_name: str = "LayerZeroOFT"
 
     def _lz_eid(self, evm_chain_id: int) -> int:
         """Map an EVM chain ID to a LayerZero v2 endpoint ID (EID)."""

--- a/pydefi/bridge/lucid.py
+++ b/pydefi/bridge/lucid.py
@@ -148,9 +148,7 @@ class LucidBridge:
             raise BridgeError(f"LucidBridge: unknown adapter_kind {self.adapter_kind!r}")
         self._cached_source_token: Address | None = None
 
-    @property
-    def protocol_name(self) -> str:
-        return "Lucid"
+    protocol_name: str = "Lucid"
 
     def _encode_bridge_options(self, refund_address: Address, gas_limit: int) -> bytes:
         # LayerZero uses uint128 gasLimit, Hyperlane uses uint256 — only field

--- a/pydefi/bridge/mayan.py
+++ b/pydefi/bridge/mayan.py
@@ -113,9 +113,7 @@ class Mayan:
         self.dst_chain_id = dst_chain_id
         self._api_base = api_base_url.rstrip("/")
 
-    @property
-    def protocol_name(self) -> str:
-        return "Mayan"
+    protocol_name: str = "Mayan"
 
     def _chain_name(self, chain_id: int) -> str:
         """Return the Mayan chain name slug for *chain_id*."""

--- a/pydefi/bridge/relay.py
+++ b/pydefi/bridge/relay.py
@@ -55,9 +55,7 @@ class Relay:
         self.dst_chain_id = dst_chain_id
         self._api_base = api_base_url.rstrip("/")
 
-    @property
-    def protocol_name(self) -> str:
-        return "Relay"
+    protocol_name: str = "Relay"
 
     async def _request_quote(
         self,

--- a/pydefi/bridge/stargate.py
+++ b/pydefi/bridge/stargate.py
@@ -76,9 +76,7 @@ class Stargate:
         self.w3 = w3
         self.router_address = router_address
 
-    @property
-    def protocol_name(self) -> str:
-        return "Stargate"
+    protocol_name: str = "Stargate"
 
     def _lz_chain_id(self, evm_chain_id: int) -> int:
         """Map an EVM chain ID to a LayerZero chain ID."""

--- a/pydefi/lending/aave_v3.py
+++ b/pydefi/lending/aave_v3.py
@@ -22,6 +22,7 @@ from typing import Any, Literal
 from eth_contract.erc20 import ERC20
 from web3 import AsyncWeb3
 
+from pydefi._utils import UINT256_MAX, resolve_amount, to_tx
 from pydefi.abi.lending import (
     AAVE_V3_ADDRESSES_PROVIDER,
     AAVE_V3_DATA_PROVIDER,
@@ -30,7 +31,7 @@ from pydefi.abi.lending import (
 )
 from pydefi.deployments import get_address
 from pydefi.exceptions import PydefiError
-from pydefi.lending.utils import SECONDS_PER_YEAR, UINT256_MAX, resolve_amount, to_tx
+from pydefi.lending.utils import SECONDS_PER_YEAR
 from pydefi.types import Address, Token, TokenAmount
 
 #: 10**27 — Aave's fixed-point scale for rates and indices.

--- a/pydefi/lending/aave_v4.py
+++ b/pydefi/lending/aave_v4.py
@@ -23,6 +23,7 @@ from typing import Any
 from eth_contract.erc20 import ERC20
 from web3 import AsyncWeb3
 
+from pydefi._utils import UINT256_MAX, to_tx
 from pydefi.abi.lending import (
     AAVE_V4_HUB,
     AAVE_V4_SPOKE,
@@ -31,7 +32,7 @@ from pydefi.abi.lending import (
 )
 from pydefi.deployments import get_address
 from pydefi.lending.aave_v3 import RAY, ray_rate_to_apy
-from pydefi.lending.utils import UINT256_MAX, WAD, to_tx
+from pydefi.lending.utils import WAD
 from pydefi.types import Address, Token, TokenAmount
 
 

--- a/pydefi/lending/compound_v3.py
+++ b/pydefi/lending/compound_v3.py
@@ -30,15 +30,10 @@ from typing import Any, Literal
 
 from web3 import AsyncWeb3
 
+from pydefi._utils import UINT256_MAX, resolve_amount, to_tx
 from pydefi.abi.lending import COMPOUND_V3_COMET
 from pydefi.deployments import comet_contract_for, get_address
-from pydefi.lending.utils import (
-    SECONDS_PER_YEAR,
-    UINT256_MAX,
-    per_second_rate_to_apy,
-    resolve_amount,
-    to_tx,
-)
+from pydefi.lending.utils import SECONDS_PER_YEAR, per_second_rate_to_apy
 from pydefi.types import Address, Token, TokenAmount
 
 #: Compound III scales rates and factors by 1e18 (no separate "RAY").

--- a/pydefi/lending/morpho.py
+++ b/pydefi/lending/morpho.py
@@ -25,9 +25,10 @@ from eth_contract.erc20 import ERC20
 from eth_utils import keccak
 from web3 import AsyncWeb3
 
+from pydefi._utils import to_tx
 from pydefi.abi.lending import MORPHO_BLUE, MORPHO_IRM, MORPHO_ORACLE, MorphoMarketParams, MorphoMarketStruct
 from pydefi.deployments import get_address
-from pydefi.lending.utils import WAD, per_second_rate_to_apy, to_tx
+from pydefi.lending.utils import WAD, per_second_rate_to_apy
 from pydefi.types import ZERO_ADDRESS, Address, Token, TokenAmount
 
 #: Morpho scales every oracle price by 1e36 (``ORACLE_PRICE_SCALE``). The

--- a/pydefi/lending/utils.py
+++ b/pydefi/lending/utils.py
@@ -1,9 +1,6 @@
 from __future__ import annotations
 
 from decimal import Decimal, getcontext
-from typing import Any, Literal
-
-from pydefi.types import Address, Token, TokenAmount
 
 #: ``type(uint256).max`` — the "full balance" sentinel for supply / withdraw /
 #: repay, and what Aave returns as the health factor of an undebted account.
@@ -45,21 +42,3 @@ def per_second_rate_to_apy(rate_per_second_wad: int) -> Decimal:
     finally:
         ctx.prec = prev
     return apy
-
-
-def resolve_amount(amount: TokenAmount | tuple[Token, Literal["max"]]) -> tuple[Token, int]:
-    """Accept either an exact :class:`TokenAmount` or ``(token, "max")``."""
-    if isinstance(amount, TokenAmount):
-        return amount.token, amount.amount
-    if isinstance(amount, tuple) and len(amount) == 2 and amount[1] == "max":
-        return amount[0], UINT256_MAX
-    raise TypeError("amount must be a TokenAmount or (Token, 'max') tuple")
-
-
-def to_tx(to: Address, call_data: bytes) -> dict[str, Any]:
-    """Format a calldata payload as the project-wide tx dict shape."""
-    return {
-        "to": to.to_0x_hex(),
-        "data": "0x" + call_data.hex(),
-        "value": "0",
-    }

--- a/pydefi/pathfinder/dag.py
+++ b/pydefi/pathfinder/dag.py
@@ -9,10 +9,66 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, TypeAlias
 
 from pydefi._math import MAX_BPS
-from pydefi.types import Address, BasePool, RouteAction, RouteBridge, RouteSplit, RouteSplitLeg, RouteSwap, Token
+from pydefi.pathfinder.graph import BasePool
+from pydefi.types import Address, Token
+
+
+@dataclass(frozen=True)
+class RouteSwap:
+    """A single swap edge in a route DAG."""
+
+    token_out: Token
+    pool: BasePool
+
+    def zero_for_one(self) -> bool:
+        return self.pool.zero_for_one(self.token_out.address)
+
+
+@dataclass(frozen=True)
+class RouteSplitLeg:
+    """One branch in a split section of a route DAG."""
+
+    fraction_bps: int
+    actions: tuple["RouteAction", ...]
+
+
+@dataclass(frozen=True)
+class RouteSplit:
+    """A split/merge section of a route DAG."""
+
+    legs: tuple[RouteSplitLeg, ...]
+    token_out: Token
+
+
+@dataclass(frozen=True)
+class RouteBridge:
+    """A cross-chain bridge edge in a route DAG (Eureka / ICS-20 today).
+
+    ``denom`` is the source-chain ERC-20 to escrow; ``token_out`` tracks the
+    destination-side type for branch-equality at ``.merge()``. Exactly one
+    of ``timeout_seconds`` (relative, resolved to ``block.timestamp + n``)
+    or ``timeout_timestamp`` (absolute) must be supplied.
+    """
+
+    denom: Address
+    token_out: Token
+    transfer_addr: Address
+    source_client: str
+    receiver: str
+    dest_port: str = "transfer"
+    memo: str = ""
+    timeout_seconds: int | None = None
+    timeout_timestamp: int | None = None
+
+    def __post_init__(self) -> None:
+        if (self.timeout_seconds is None) == (self.timeout_timestamp is None):
+            raise ValueError("RouteBridge: supply exactly one of timeout_seconds / timeout_timestamp")
+
+
+RouteAction: TypeAlias = RouteSwap | RouteSplit | RouteBridge
 
 
 @dataclass

--- a/pydefi/pathfinder/graph.py
+++ b/pydefi/pathfinder/graph.py
@@ -14,7 +14,21 @@ from dataclasses import dataclass, field
 from decimal import Decimal
 from typing import Callable, ClassVar, Iterator
 
-from pydefi.types import ZERO_ADDRESS, Address, BasePool, Token
+from pydefi.types import ZERO_ADDRESS, Address, SwapProtocol, Token
+
+
+class BasePool:
+    """Base class for pool descriptors used by RouteDAG actions.
+
+    Subclasses (e.g. :class:`PoolEdge`) must override :meth:`zero_for_one`.
+    """
+
+    pool_address: Address
+    protocol: SwapProtocol
+    fee_bps: int
+
+    def zero_for_one(self, token_out: Address) -> bool:
+        raise NotImplementedError("BasePool.zero_for_one() must be implemented by subclasses")
 
 
 @dataclass

--- a/pydefi/pathfinder/router.py
+++ b/pydefi/pathfinder/router.py
@@ -18,9 +18,9 @@ from decimal import Decimal
 
 from pydefi._math import MAX_BPS
 from pydefi.exceptions import NoRouteFoundError
-from pydefi.pathfinder.dag import RouteDAG
+from pydefi.pathfinder.dag import RouteDAG, RouteSplit, RouteSwap
 from pydefi.pathfinder.graph import PoolEdge, PoolGraph
-from pydefi.types import ZERO_ADDRESS, Address, RouteSplit, RouteSwap, SwapRoute, SwapStep, Token, TokenAmount
+from pydefi.types import ZERO_ADDRESS, Address, SwapRoute, SwapStep, Token, TokenAmount
 
 #: Full pool identity: ``(pool_address, token_in, fee, tick_spacing, hooks)``.
 #: ``pool_address`` alone is not unique — every Uniswap V4 pool on a chain

--- a/pydefi/types.py
+++ b/pydefi/types.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from decimal import ROUND_DOWN, Decimal
 from enum import Enum, IntEnum
-from typing import TYPE_CHECKING, TypeAlias
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from pydefi.pathfinder.dag import RouteDAG  # noqa: F401
@@ -222,92 +222,6 @@ class SwapProtocol(str, Enum):
 
     UNISWAP_V4 = "uniswap_v4"
     """Uniswap V4 pool, traded via the singleton PoolManager."""
-
-
-class BasePool:
-    """Base class for pool descriptors used by RouteDAG actions.
-
-    Subclasses (e.g. :class:`~pydefi.pathfinder.graph.PoolEdge`) must
-    override :meth:`zero_for_one`.
-    """
-
-    pool_address: Address
-    protocol: SwapProtocol
-    fee_bps: int
-
-    def zero_for_one(self, token_out: Address) -> bool:
-        raise NotImplementedError("BasePool.zero_for_one() must be implemented by subclasses")
-
-
-@dataclass(frozen=True)
-class RouteSwap:
-    """A single swap edge in a route DAG."""
-
-    token_out: Token
-    pool: BasePool
-
-    def zero_for_one(self) -> bool:
-        return self.pool.zero_for_one(self.token_out.address)
-
-
-@dataclass(frozen=True)
-class RouteSplitLeg:
-    """One branch in a split section of a route DAG."""
-
-    fraction_bps: int
-    actions: tuple[RouteAction, ...]
-
-
-@dataclass(frozen=True)
-class RouteSplit:
-    """A split/merge section of a route DAG."""
-
-    legs: tuple[RouteSplitLeg, ...]
-    token_out: Token
-
-
-@dataclass(frozen=True)
-class RouteBridge:
-    """A cross-chain bridge edge in a route DAG (Eureka / ICS-20 today).
-
-    ``denom`` is the source-chain ERC-20 to escrow; ``token_out`` tracks the
-    destination-side type for branch-equality at ``.merge()``. Exactly one
-    of ``timeout_seconds`` (relative, resolved to ``block.timestamp + n``)
-    or ``timeout_timestamp`` (absolute) must be supplied.
-    """
-
-    denom: Address
-    token_out: Token
-    transfer_addr: Address
-    source_client: str
-    receiver: str
-    dest_port: str = "transfer"
-    memo: str = ""
-    timeout_seconds: int | None = None
-    timeout_timestamp: int | None = None
-
-    def __post_init__(self) -> None:
-        if (self.timeout_seconds is None) == (self.timeout_timestamp is None):
-            raise ValueError("RouteBridge: supply exactly one of timeout_seconds / timeout_timestamp")
-
-
-RouteAction: TypeAlias = RouteSwap | RouteSplit | RouteBridge
-
-
-@dataclass
-class SwapTransaction:
-    """An encoded transaction ready to submit to the Uniswap Universal Router.
-
-    Attributes:
-        to: Target contract address (the Universal Router).
-        data: ABI-encoded calldata for the ``execute`` call.
-        value: Amount of native ETH (in wei) to attach to the transaction.
-            Typically non-zero only when wrapping ETH as part of the swap.
-    """
-
-    to: str
-    data: bytes
-    value: int = 0
 
 
 @dataclass

--- a/pydefi/vm/dag.py
+++ b/pydefi/vm/dag.py
@@ -12,16 +12,8 @@ from __future__ import annotations
 
 from collections.abc import Callable, Sequence
 
-from pydefi.pathfinder.dag import RouteDAG
-from pydefi.types import (
-    ZERO_ADDRESS,
-    Address,
-    RouteAction,
-    RouteBridge,
-    RouteSplit,
-    RouteSwap,
-    SwapProtocol,
-)
+from pydefi.pathfinder.dag import RouteAction, RouteBridge, RouteDAG, RouteSplit, RouteSwap
+from pydefi.types import ZERO_ADDRESS, Address, SwapProtocol
 from pydefi.vm.context import Operand, Program
 from pydefi.vm.eureka import approve_then_send_transfer
 from pydefi.vm.swap import (

--- a/pydefi/vm/eip7702_supply.py
+++ b/pydefi/vm/eip7702_supply.py
@@ -17,9 +17,9 @@ from eth_account import Account
 from eth_utils import keccak
 from hexbytes import HexBytes
 
+from pydefi._utils import to_tx
 from pydefi.abi.vm import CALIBUR as _CALIBUR_ABI
 from pydefi.deployments import get_address
-from pydefi.lending.utils import to_tx
 from pydefi.types import ZERO_ADDRESS, Address, ChainId
 
 #: Calibur v1.0.0 singleton — one address on every chain it is deployed on;
@@ -215,7 +215,7 @@ def build_execute_tx(
     # Calibur expects ``abi.encode(bytes signature, bytes hookData)``.
     wrapped_signature = abi_encode(["bytes", "bytes"], [signature, b""])
     data = _CALIBUR_ABI.fns.execute(signed_batched_call, wrapped_signature).data
-    tx: dict[str, Any] = {**to_tx(eoa, data), "gas": str(gas)}
+    tx: dict[str, Any] = to_tx(eoa, data, gas= gas)
     if authorization is not None:
         tx["type"] = 4
         tx["authorizationList"] = [_auth_to_dict(authorization)]

--- a/pydefi/vm/eip7702_supply.py
+++ b/pydefi/vm/eip7702_supply.py
@@ -215,7 +215,7 @@ def build_execute_tx(
     # Calibur expects ``abi.encode(bytes signature, bytes hookData)``.
     wrapped_signature = abi_encode(["bytes", "bytes"], [signature, b""])
     data = _CALIBUR_ABI.fns.execute(signed_batched_call, wrapped_signature).data
-    tx: dict[str, Any] = to_tx(eoa, data, gas= gas)
+    tx: dict[str, Any] = to_tx(eoa, data, gas=gas)
     if authorization is not None:
         tx["type"] = 4
         tx["authorizationList"] = [_auth_to_dict(authorization)]

--- a/pydefi/vm/permit2_supply.py
+++ b/pydefi/vm/permit2_supply.py
@@ -125,4 +125,4 @@ def build_supply_tx(
     """Encode ``DeFiVM.executeWithPermit2(...)`` into a broadcast-ready tx dict."""
     permit = ([(token.to_0x_hex(), amount) for token, amount in permitted], nonce, deadline)
     data = DeFiVM.fns.executeWithPermit2(permit, owner.to_0x_hex(), signature, program).data
-    return to_tx(defivm, data, gas= gas)
+    return to_tx(defivm, data, gas=gas)

--- a/pydefi/vm/permit2_supply.py
+++ b/pydefi/vm/permit2_supply.py
@@ -15,8 +15,8 @@ from eth_contract import Contract
 from eth_contract.erc20 import ERC20
 from eth_utils import keccak
 
+from pydefi._utils import UINT256_MAX, to_tx
 from pydefi.abi.vm import DeFiVM
-from pydefi.lending.utils import UINT256_MAX, to_tx
 from pydefi.types import Address
 from pydefi.vm.context import Program
 
@@ -125,4 +125,4 @@ def build_supply_tx(
     """Encode ``DeFiVM.executeWithPermit2(...)`` into a broadcast-ready tx dict."""
     permit = ([(token.to_0x_hex(), amount) for token, amount in permitted], nonce, deadline)
     data = DeFiVM.fns.executeWithPermit2(permit, owner.to_0x_hex(), signature, program).data
-    return {**to_tx(defivm, data), "gas": str(gas)}
+    return to_tx(defivm, data, gas= gas)

--- a/pydefi/vm/swap.py
+++ b/pydefi/vm/swap.py
@@ -16,9 +16,26 @@ from eth_contract.erc20 import ERC20
 from eth_utils import keccak
 
 from pydefi.abi.amm import UNISWAP_V2_PAIR, UNISWAP_V3_POOL, UNISWAP_V3_QUOTER_V2
-from pydefi.pathfinder.dag import RouteDAG
-from pydefi.types import Address, RouteSwap, SwapProtocol, SwapRoute, SwapTransaction
+from pydefi.pathfinder.dag import RouteDAG, RouteSwap
+from pydefi.types import Address, SwapProtocol, SwapRoute
 from pydefi.vm.context import Operand, Program
+
+
+@dataclass
+class SwapTransaction:
+    """An encoded transaction ready to submit to the Uniswap Universal Router.
+
+    Attributes:
+        to: Target contract address (the Universal Router).
+        data: ABI-encoded calldata for the ``execute`` call.
+        value: Amount of native ETH (in wei) to attach to the transaction.
+            Typically non-zero only when wrapping ETH as part of the swap.
+    """
+
+    to: str
+    data: bytes
+    value: int = 0
+
 
 # ---------------------------------------------------------------------------
 # Pool / quoter / token function ABI signatures (sourced from pydefi.abi)

--- a/pydefi/vm/yield_deposit.py
+++ b/pydefi/vm/yield_deposit.py
@@ -21,11 +21,11 @@ from typing import Any
 from eth_contract.erc20 import ERC20
 from eth_utils import keccak, to_checksum_address
 
+from pydefi._utils import to_tx
 from pydefi.abi.safe import SAFE as _SAFE_ABI
 from pydefi.abi.safe import SAFE_PROXY_FACTORY as _FACTORY_ABI
 from pydefi.abi.vm import DeFiVM
 from pydefi.deployments import get_address
-from pydefi.lending.utils import to_tx
 from pydefi.types import ZERO_ADDRESS, Address, ChainId
 from pydefi.vm.context import Program
 
@@ -109,4 +109,4 @@ def build_sweep_tx(
     sweeps the balance; broadcast by any relayer (which earns the committed fee)."""
     initializer = build_initializer(owner, defivm, program)
     data = _FACTORY_ABI.fns.createProxyWithNonce(SAFE_SINGLETON.to_0x_hex(), initializer, salt_nonce).data
-    return {**to_tx(SAFE_PROXY_FACTORY, data), "gas": str(gas)}
+    return to_tx(SAFE_PROXY_FACTORY, data, gas=gas)

--- a/tests/live/test_router_live.py
+++ b/tests/live/test_router_live.py
@@ -10,10 +10,10 @@ import pytest
 from eth_contract import Contract
 
 from pydefi.exceptions import NoRouteFoundError
-from pydefi.pathfinder.dag import RouteDAG
+from pydefi.pathfinder.dag import RouteDAG, RouteSplit
 from pydefi.pathfinder.graph import PoolGraph, V3PoolEdge
 from pydefi.pathfinder.router import Router
-from pydefi.types import RouteSplit, TokenAmount
+from pydefi.types import TokenAmount
 from pydefi.vm import build_quote_program_for_dag
 from tests.addrs import (
     DAI,

--- a/tests/test_amm.py
+++ b/tests/test_amm.py
@@ -22,7 +22,8 @@ from pydefi.amm.universal_router import (
     V4Hop,
 )
 from pydefi.exceptions import InsufficientLiquidityError
-from pydefi.types import Address, SwapTransaction, TokenAmount
+from pydefi.types import Address, TokenAmount
+from pydefi.vm.swap import SwapTransaction
 from tests.addrs import (
     DAI,
     ETH_WHALE,

--- a/tests/test_pathfinder.py
+++ b/tests/test_pathfinder.py
@@ -6,10 +6,10 @@ from decimal import Decimal
 import pytest
 
 from pydefi.exceptions import NoRouteFoundError
-from pydefi.pathfinder.dag import RouteDAG
+from pydefi.pathfinder.dag import RouteDAG, RouteSwap
 from pydefi.pathfinder.graph import PoolEdge, PoolGraph, V3PoolEdge
 from pydefi.pathfinder.router import Router, _estimate_price_impact
-from pydefi.types import Address, ChainId, RouteSwap, Token, TokenAmount
+from pydefi.types import Address, ChainId, Token, TokenAmount
 from tests.addrs import DAI, USDC, WETH
 
 # ---------------------------------------------------------------------------
@@ -732,7 +732,7 @@ class TestFindBestSplit:
         dag = router.find_best_split(TokenAmount(WETH, 10**18), USDC)
         payload = dag.to_dict()
         assert payload["token_in"] == WETH
-        from pydefi.types import RouteSplit
+        from pydefi.pathfinder.dag import RouteSplit
 
         assert not any(isinstance(a, RouteSplit) for a in payload["actions"])
         assert payload["actions"][-1].token_out == USDC
@@ -755,7 +755,7 @@ class TestFindBestSplit:
         input: price impact per pool is ~9% for 100% allocation but only ~5%
         per pool for 50/50, so splitting strictly wins.
         """
-        from pydefi.types import RouteSplit
+        from pydefi.pathfinder.dag import RouteSplit
 
         g = PoolGraph()
         g.add_pool(
@@ -780,7 +780,7 @@ class TestFindBestSplit:
         router = Router(g)
         dag = router.find_best_split(TokenAmount(WETH, 10**18), USDC, max_splits=1)
         payload = dag.to_dict()
-        from pydefi.types import RouteSplit
+        from pydefi.pathfinder.dag import RouteSplit
 
         assert not any(isinstance(a, RouteSplit) for a in payload["actions"])
 
@@ -890,7 +890,7 @@ class TestRouterSimulate:
         result = router.simulate(dag, amount_in)
 
         # Manual: each leg gets amount_in * bps / 10000
-        from pydefi.types import RouteSplit
+        from pydefi.pathfinder.dag import RouteSplit
 
         payload = dag.to_dict()
         split = payload["actions"][0]

--- a/tests/test_program.py
+++ b/tests/test_program.py
@@ -7,8 +7,9 @@ from eth_contract.contract import ContractFunction
 from hexbytes import HexBytes
 
 from pydefi.bridge.eureka import encode_send_transfer_calldata
-from pydefi.pathfinder.dag import RouteDAG
-from pydefi.types import Address, BasePool, ChainId, RouteBridge, SwapProtocol, Token
+from pydefi.pathfinder.dag import RouteBridge, RouteDAG
+from pydefi.pathfinder.graph import BasePool
+from pydefi.types import Address, ChainId, SwapProtocol, Token
 from pydefi.vm import (
     IIBC_SENDER_CALLBACKS_INTERFACE_ID,
     Operand,

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -4,13 +4,11 @@ from decimal import Decimal
 
 import pytest
 
-from pydefi.pathfinder.dag import RouteDAG
+from pydefi.pathfinder.dag import RouteDAG, RouteSplit, RouteSwap
 from pydefi.types import (
     Address,
     BridgeQuote,
     ChainId,
-    RouteSplit,
-    RouteSwap,
     SwapRoute,
     SwapStep,
     Token,


### PR DESCRIPTION
refactor: eliminate duplication and tighten type ownership

Phase 1-2: AggregatorQuote methods

Add `AggregatorQuote.to_swap_route()` to replace 7 identical `build_swap_route` implementations across aggregators.

Add `AggregatorQuote.from_quote()` classmethod to replace repeated `AggregatorQuote(...)` construction with inline `apply_slippage` in every `get_quote`/`get_swap`.  UniswapAPI and Jupiter keep their original constructions because their `min_amount_out` comes from the API response rather than `apply_slippage`.

Phase 4: types.py split

Move `BasePool` to pydefi/pathfinder/graph.py (its sole user). Move `RouteSwap`, `RouteSplit`, `RouteSplitLeg`, `RouteBridge`, `RouteAction` to pydefi/pathfinder/dag.py (DAG-internal types). Move `SwapTransaction` to pydefi/vm/swap.py (its sole producer).

types.py now holds only pure infrastructure types: Address, Hash, ChainId, Token, TokenAmount, SwapStep, SwapRoute, SwapProtocol, BridgeQuote.

Phase 5: Small cleanups

Promote `to_tx()` / `resolve_amount()` from lending/utils.py to _utils.py; they were never lending-specific.

Convert 20 hardcoded `@property def protocol_name` to class attributes (`protocol_name: str = "..."`).

Remove now-unused Eureka.PROTOCOL class attr and unused `apply_slippage`/`SwapStep`/`SwapRoute` imports from modules that no longer need them.