### PR TITLE
Problem: DeFiVM can't execute Uniswap V4 swaps

### DIFF
--- a/pydefi/abi/amm.py
+++ b/pydefi/abi/amm.py
@@ -197,21 +197,29 @@ UNISWAP_V4_POOL_MANAGER = Contract.from_abi(
 # :mod:`pydefi.vm.swap` to build calldata for V4 swaps.
 # ---------------------------------------------------------------------------
 
-#: ABI fragment for the 10-word payload passed inside ``PoolManager.unlock(data)``.
-#: Layout: ``c0, c1, fee, tickSpacing, hooks, zeroForOne, amountSpecified,
-#: sqrtPriceLimitX96, tokenIn, recipient``.  Decoded by ``DeFiVM.unlockCallback``.
-V4_UNLOCK_DATA_TYPES: list[str] = [
-    "address",  # currency0
-    "address",  # currency1
-    "uint24",  # fee (pips)
-    "int24",  # tickSpacing
-    "address",  # hooks
-    "bool",  # zeroForOne
-    "int256",  # amountSpecified (negative for exactInput)
-    "uint160",  # sqrtPriceLimitX96
-    "address",  # tokenIn
-    "address",  # recipient
-]
+
+class V4UnlockData(ABIStruct):
+    """The 10-word payload passed inside ``PoolManager.unlock(data)``.
+
+    Flattens v4-core ``PoolKey`` (currency0, currency1, fee, tickSpacing,
+    hooks) and ``SwapParams`` (zeroForOne, amountSpecified, sqrtPriceLimitX96)
+    plus ``tokenIn`` / ``recipient`` the callback settles and pays out.
+    Every field is static, so this encodes byte-identically to the
+    ``(PoolKey, SwapParams, address, address)`` tuple that
+    ``DEXCallbackRouter.unlockCallback`` decodes.
+    """
+
+    currency0: Annotated[str, "address"]
+    currency1: Annotated[str, "address"]
+    fee: Annotated[int, "uint24"]  # pips
+    tickSpacing: Annotated[int, "int24"]
+    hooks: Annotated[str, "address"]
+    zeroForOne: Annotated[bool, "bool"]
+    amountSpecified: Annotated[int, "int256"]  # negative for exactInput
+    sqrtPriceLimitX96: Annotated[int, "uint160"]
+    tokenIn: Annotated[str, "address"]
+    recipient: Annotated[str, "address"]
+
 
 #: Calldata byte offset of ``amountSpecified`` (word 6 of the unlock data) in
 #: the full ``unlock(bytes)`` calldata.

--- a/pydefi/abi/amm.py
+++ b/pydefi/abi/amm.py
@@ -184,6 +184,45 @@ UNISWAP_V4_QUOTER = Contract.from_abi(
     ]
 )
 
+UNISWAP_V4_POOL_MANAGER = Contract.from_abi(
+    [
+        "function unlock(bytes data) external returns (bytes memory)",
+    ]
+)
+
+# ---------------------------------------------------------------------------
+# Uniswap V4 — DeFiVM swap composer constants
+#
+# Layout offsets and the ABI fragment used by the SSA composer in
+# :mod:`pydefi.vm.swap` to build calldata for V4 swaps.
+# ---------------------------------------------------------------------------
+
+#: ABI fragment for the 10-word payload passed inside ``PoolManager.unlock(data)``.
+#: Layout: ``c0, c1, fee, tickSpacing, hooks, zeroForOne, amountSpecified,
+#: sqrtPriceLimitX96, tokenIn, recipient``.  Decoded by ``DeFiVM.unlockCallback``.
+V4_UNLOCK_DATA_TYPES: list[str] = [
+    "address",  # currency0
+    "address",  # currency1
+    "uint24",  # fee (pips)
+    "int24",  # tickSpacing
+    "address",  # hooks
+    "bool",  # zeroForOne
+    "int256",  # amountSpecified (negative for exactInput)
+    "uint160",  # sqrtPriceLimitX96
+    "address",  # tokenIn
+    "address",  # recipient
+]
+
+#: Calldata byte offset of ``amountSpecified`` (word 6 of the unlock data) in
+#: the full ``unlock(bytes)`` calldata.
+#: ``4 (selector) + 32 (bytes-arg offset) + 32 (bytes-arg length) + 6*32 = 260``.
+V4_UNLOCK_AMOUNT_SPEC_OFFSET: int = 260
+
+#: Byte offset of ``amountOut`` in the returndata of ``unlock()``.  The
+#: PoolManager wraps DeFiVM's ``abi.encode(amountOut)`` as ``bytes memory``:
+#: ``[0..32) offset, [32..64) length, [64..96) amountOut``.
+V4_UNLOCK_AMOUNT_OUT_OFFSET: int = 64
+
 # ---------------------------------------------------------------------------
 # Curve Finance
 # ---------------------------------------------------------------------------

--- a/pydefi/pathfinder/router.py
+++ b/pydefi/pathfinder/router.py
@@ -105,6 +105,11 @@ class Router:
         self.graph = graph
         self.max_hops = max_hops
 
+    @staticmethod
+    def dag_leg_weights(dag: RouteDAG) -> list[int]:
+        """Return ``fraction_bps`` for each split leg, or ``[10000]`` for a linear DAG."""
+        return _dag_leg_weights(dag)
+
     def find_best_route(
         self,
         amount_in: TokenAmount,

--- a/pydefi/vm/DEXCallbackRouter.sol
+++ b/pydefi/vm/DEXCallbackRouter.sol
@@ -1,13 +1,44 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
+/// @dev Uniswap V4 ``PoolKey`` — ``(currency0, currency1)`` sorted ascending by
+///      address; ``currency == address(0)`` denotes native ETH.
+struct V4PoolKey {
+    address currency0;
+    address currency1;
+    uint24 fee;
+    int24 tickSpacing;
+    address hooks;
+}
+
+/// @dev Uniswap V4 swap params.  Exact-input uses a negative ``amountSpecified``.
+struct V4SwapParams {
+    bool zeroForOne;
+    int256 amountSpecified;
+    uint160 sqrtPriceLimitX96;
+}
+
+/// @dev Minimal Uniswap V4 ``PoolManager`` surface used to settle a single swap
+///      inside ``unlockCallback``: ``swap`` then sync→pay→settle the input debt
+///      and ``take`` the output.  ``swap`` returns a ``BalanceDelta`` (an
+///      ``int256`` packing ``amount0`` in the high 128 bits, ``amount1`` low).
+interface IV4PoolManager {
+    function swap(V4PoolKey memory key, V4SwapParams memory params, bytes calldata hookData)
+        external
+        returns (int256 balanceDelta);
+    function sync(address currency) external;
+    function settle() external payable returns (uint256 paid);
+    function take(address currency, address to, uint256 amount) external;
+}
+
 /**
  * @title DEXCallbackRouter
- * @notice Mixin that answers V2/V3 DEX swap callbacks for the inheriting
- *         contract.  Programs run in the caller's context (DELEGATECALL),
- *         so any pool callback comes back to whichever contract initiated
- *         the swap (DeFiVM, CCTPComposer, OFTComposer, ApproveProxy);
- *         inheriting this keeps the routing logic in one place.
+ * @notice Mixin that answers V2/V3 DEX swap callbacks and the Uniswap V4
+ *         ``unlockCallback`` for the inheriting contract.  Programs run in the
+ *         caller's context (DELEGATECALL), so any pool callback comes back to
+ *         whichever contract initiated the swap (DeFiVM, CCTPComposer,
+ *         OFTComposer, ApproveProxy); inheriting this keeps the routing logic
+ *         in one place.
  *
  * ``data`` encoding (set by the program when calling pool.swap):
  *  • V3 (uniswapV3 / algebra / pancakeV3 / solidlyV3):
@@ -15,6 +46,8 @@ pragma solidity ^0.8.24;
  *  • V2 (uniswapV2Call / Aerodrome hook / ramsesV2FlashCallback):
  *      ``abi.encode(address tokenIn, uint256 amountOwed)`` — ``amountOwed``
  *      is paid to the pool.
+ *  • V4: the swap runs inside ``PoolManager.unlock(data)``; ``unlockCallback``
+ *      below decodes the 10-word payload, performs the swap, and settles it.
  *
  * No caller whitelist; safety relies on the program being atomic and
  * leaving no balance or allowance behind.  Simulate before broadcasting.
@@ -111,6 +144,54 @@ abstract contract DEXCallbackRouter {
         } else {
             revert("DEXCallbackRouter: unknown callback selector");
         }
+    }
+
+    /**
+     * @notice Uniswap V4 unlock callback.  ``PoolManager.unlock(data)`` calls
+     *         this back on the unlocker (whichever contract initiated the
+     *         swap); ``msg.sender`` is therefore the PoolManager.
+     *
+     * ``data`` is the 10-word payload built by
+     * ``pydefi.vm.swap._build_v4_swap``:
+     *   ``(currency0, currency1, fee, tickSpacing, hooks, zeroForOne,
+     *      amountSpecified, sqrtPriceLimitX96, tokenIn, recipient)``.
+     *
+     * The input debt (negative delta on ``tokenIn``) is paid via
+     * sync→transfer→settle, or ``settle{value}`` when ``tokenIn`` is native ETH
+     * (``address(0)``).  The output (positive delta) is taken to ``recipient``.
+     * Returns ``abi.encode(amountOut)``, which ``unlock`` forwards verbatim to
+     * the calling program (read at returndata offset 64).
+     */
+    function unlockCallback(bytes calldata data) external returns (bytes memory) {
+        address pm = msg.sender;
+        // V4PoolKey and V4SwapParams are static structs (no dynamic fields), so
+        // the flat 10-word payload that pydefi.vm.swap._build_v4_swap encodes
+        // decodes inline, straight into the swap arguments.
+        (V4PoolKey memory key, V4SwapParams memory params, address tokenIn, address recipient) =
+            abi.decode(data, (V4PoolKey, V4SwapParams, address, address));
+
+        int256 delta = IV4PoolManager(pm).swap(key, params, "");
+
+        // BalanceDelta packs amount0 in the high 128 bits, amount1 in the low.
+        // Exact-input: the input currency carries the negative (owed) delta and
+        // the output currency the positive (receivable) delta, keyed off
+        // ``zeroForOne`` (selling currency0 → input is amount0).
+        uint256 owed = uint256(uint128(-int128(params.zeroForOne ? delta >> 128 : delta)));
+        uint256 amountOut = uint256(uint128(int128(params.zeroForOne ? delta : delta >> 128)));
+
+        // Settle the input debt.
+        if (tokenIn == address(0)) {
+            IV4PoolManager(pm).settle{value: owed}();
+        } else {
+            IV4PoolManager(pm).sync(tokenIn);
+            _callTransfer(tokenIn, pm, owed);
+            IV4PoolManager(pm).settle();
+        }
+
+        // Take the output to the recipient (the VM itself for intermediate hops).
+        IV4PoolManager(pm).take(params.zeroForOne ? key.currency1 : key.currency0, recipient, amountOut);
+
+        return abi.encode(amountOut);
     }
 
     /**

--- a/pydefi/vm/swap.py
+++ b/pydefi/vm/swap.py
@@ -10,14 +10,26 @@ Python instead of via an implicit EVM stack contract.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
 
 from eth_abi import encode
 from eth_contract.erc20 import ERC20
 from eth_utils import keccak
 
-from pydefi.abi.amm import UNISWAP_V2_PAIR, UNISWAP_V3_POOL, UNISWAP_V3_QUOTER_V2
+if TYPE_CHECKING:
+    from web3 import AsyncWeb3
+
+from pydefi.abi.amm import (
+    UNISWAP_V2_PAIR,
+    UNISWAP_V3_POOL,
+    UNISWAP_V3_QUOTER_V2,
+    UNISWAP_V4_POOL_MANAGER,
+    V4_UNLOCK_AMOUNT_OUT_OFFSET,
+    V4_UNLOCK_AMOUNT_SPEC_OFFSET,
+    V4_UNLOCK_DATA_TYPES,
+)
 from pydefi.pathfinder.dag import RouteDAG, RouteSwap
-from pydefi.types import Address, SwapProtocol, SwapRoute
+from pydefi.types import ZERO_ADDRESS, Address, SwapProtocol, SwapRoute, TokenAmount
 from pydefi.vm.context import Operand, Program
 
 
@@ -45,6 +57,7 @@ _V3_POOL_SWAP_FN = UNISWAP_V3_POOL.fns.swap
 _V2_PAIR_SWAP_FN = UNISWAP_V2_PAIR.fns.swap
 _V2_PAIR_GET_RESERVES_FN = UNISWAP_V2_PAIR.fns.getReserves
 _V3_QUOTER_QUOTE_EXACT_INPUT_FN = UNISWAP_V3_QUOTER_V2.fns.quoteExactInput
+_V4_PM_UNLOCK_FN = UNISWAP_V4_POOL_MANAGER.fns.unlock
 _ERC20_TRANSFER_FN = ERC20.fns.transfer
 
 # V3 sqrtPriceLimitX96 boundaries (TickMath.MIN/MAX_SQRT_RATIO ± 1)
@@ -122,6 +135,10 @@ class SwapHop:
     recipient: Address
     zero_for_one: bool
     sqrt_price_limit_x96: int = field(default=0)
+    #: V4 only — tick spacing from the pool key (e.g. ``60`` for 0.3 % fee).
+    tick_spacing: int = field(default=0)
+    #: V4 only — hooks contract address, or zero address for hookless pools.
+    hooks: Address = ZERO_ADDRESS
 
 
 # ---------------------------------------------------------------------------
@@ -235,6 +252,57 @@ def _build_v2_direct_swap(prog: Program, amount_in: Operand, hop: SwapHop) -> Op
     return amount_out
 
 
+def _v4_pool_key_currencies(hop: SwapHop) -> tuple[Address, Address]:
+    """Return ``(currency0, currency1)`` for the V4 PoolKey, sorted by address."""
+    if hop.token_in.lower() < hop.token_out.lower():
+        return hop.token_in, hop.token_out
+    return hop.token_out, hop.token_in
+
+
+def _build_v4_swap(prog: Program, amount_in: Operand, hop: SwapHop) -> Operand:
+    """V4 pool direct swap via ``PoolManager.unlock()``.
+
+    Builds calldata for ``unlock(bytes data)`` where *data* encodes the PoolKey
+    and SwapParams as 10 packed words.  ``amountSpecified`` (word 6) is set to
+    ``0`` in the static template and overlaid at runtime with the two's-complement
+    negation of *amount_in* (V4 exactInput uses negative ``amountSpecified``).
+    The PoolManager fires ``unlockCallback(bytes)`` back into the VM's
+    ``DEXCallbackRouter.unlockCallback`` handler, which performs
+    sync→transfer→settle→take and returns ``abi.encode(amountOut)``.
+    """
+    sqrt_price_limit = hop.sqrt_price_limit_x96 or (_SQRT_PRICE_MIN if hop.zero_for_one else _SQRT_PRICE_MAX)
+    c0, c1 = _v4_pool_key_currencies(hop)
+
+    # Word layout matches the unlockCallback decoder in DEXCallbackRouter.sol:
+    #   c0(0), c1(1), fee(2), tickSpacing(3), hooks(4),
+    #   zeroForOne(5), amountSpecified(6), sqrtPriceLimitX96(7),
+    #   tokenIn(8), recipient(9)
+    # V4 PoolKey fee is uint24 in pips (1/1_000_000), e.g. 3000 = 0.3 %.
+    data_bytes = encode(
+        V4_UNLOCK_DATA_TYPES,
+        [
+            c0,
+            c1,
+            hop.fee_bps * 100,
+            hop.tick_spacing,
+            hop.hooks,
+            hop.zero_for_one,
+            0,
+            sqrt_price_limit,
+            hop.token_in,
+            hop.recipient,
+        ],
+    )
+    calldata = bytes(_V4_PM_UNLOCK_FN(data_bytes).data)
+
+    # Patch amountSpecified with -amount_in (two's-complement negation: NOT(x) + 1).
+    negated_amount = prog.add(prog.bit_not(amount_in), 1)
+    success = prog.call_raw(hop.pool, calldata, patches={V4_UNLOCK_AMOUNT_SPEC_OFFSET: negated_amount})
+    prog.assert_(success)
+
+    return prog.returndata_word(V4_UNLOCK_AMOUNT_OUT_OFFSET)
+
+
 # ---------------------------------------------------------------------------
 # Protocol resolution
 # ---------------------------------------------------------------------------
@@ -270,17 +338,17 @@ def _swap_hop_from_route_swap(swap_action: RouteSwap, *, recipient: Address) -> 
         fee_bps=pool.fee_bps,
         recipient=recipient,
         zero_for_one=swap_action.zero_for_one(),
+        tick_spacing=getattr(pool, "tick_spacing", 0),
+        hooks=getattr(pool, "hooks", ZERO_ADDRESS),
     )
 
 
 def _build_route_swap(prog: Program, amount_in: Operand, action: RouteSwap, recipient: Address) -> Operand:
     hop = _swap_hop_from_route_swap(action, recipient=recipient)
-    if hop.protocol == SwapProtocol.UNISWAP_V4:
-        raise NotImplementedError(
-            "Uniswap V4 execution is not supported by DeFiVM; build the swap via UniversalRouter (V4_SWAP) instead"
-        )
     if hop.protocol == SwapProtocol.UNISWAP_V3:
         return _build_v3_pool_swap(prog, amount_in, hop)
+    if hop.protocol == SwapProtocol.UNISWAP_V4:
+        return _build_v4_swap(prog, amount_in, hop)
     return _build_v2_direct_swap(prog, amount_in, hop)
 
 
@@ -345,6 +413,39 @@ def swap_route_to_hops(route: SwapRoute, vm_address: str, recipient: str) -> lis
                 fee_bps=step.fee,
                 recipient=Address(hop_recipient),
                 zero_for_one=zero_for_one,
+                tick_spacing=getattr(step, "tick_spacing", 0),
+                hooks=getattr(step, "hooks", ZERO_ADDRESS),
             )
         )
     return hops
+
+
+async def quote_swap_transaction(
+    w3: "AsyncWeb3",
+    dag: RouteDAG,
+    *,
+    amount_in: int,
+    vm_address: Address,
+    quoter_address: Address | None = None,
+) -> TokenAmount:
+    """Simulate a swap via ``eth_call`` on the DeFiVM contract — V2 and V3 only.
+
+    Composes a DeFiVM quote program from *dag* via
+    :func:`~pydefi.vm.dag.build_quote_program_for_dag` and executes it against
+    *vm_address*.  No tokens are transferred; the program reads pool state
+    on-chain and returns the estimated output amount.
+
+    *quoter_address* (the QuoterV2 address) is required when the DAG contains V3
+    hops.  In-VM V4 quoting is not supported — ``build_quote_program_for_dag``
+    raises for V4 hops; quote a V4 leg off-chain via
+    :meth:`pydefi.amm.uniswap_v4.UniswapV4.quote_exact_input_single` instead.
+    """
+    from pydefi.vm.dag import build_quote_program_for_dag
+
+    if not dag.actions:
+        raise ValueError("quote_swap_transaction: route DAG must contain at least one action")
+
+    program = build_quote_program_for_dag(dag, amount_in=amount_in, quoter_address=quoter_address)
+    calldata = _EXECUTE_SELECTOR + encode(["bytes"], [bytes(program.build())])
+    result = await w3.eth.call({"to": vm_address, "data": calldata})
+    return TokenAmount(token=dag.actions[-1].token_out, amount=int.from_bytes(result[:32], "big"))

--- a/pydefi/vm/swap.py
+++ b/pydefi/vm/swap.py
@@ -135,6 +135,10 @@ class SwapHop:
     recipient: Address
     zero_for_one: bool
     sqrt_price_limit_x96: int = field(default=0)
+    #: V4 only — the exact PoolKey fee in pips (1e-6).  ``fee_bps`` truncates
+    #: sub-bps / non-100-multiple fees, which would select the wrong PoolKey
+    #: (and a non-existent pool) at execution; this carries the unrounded value.
+    fee_pips: int = field(default=0)
     #: V4 only — tick spacing from the pool key (e.g. ``60`` for 0.3 % fee).
     tick_spacing: int = field(default=0)
     #: V4 only — hooks contract address, or zero address for hookless pools.
@@ -277,13 +281,15 @@ def _build_v4_swap(prog: Program, amount_in: Operand, hop: SwapHop) -> Operand:
     #   c0(0), c1(1), fee(2), tickSpacing(3), hooks(4),
     #   zeroForOne(5), amountSpecified(6), sqrtPriceLimitX96(7),
     #   tokenIn(8), recipient(9)
-    # V4 PoolKey fee is uint24 in pips (1/1_000_000), e.g. 3000 = 0.3 %.
+    # V4 PoolKey fee is uint24 in pips (1/1_000_000), e.g. 3000 = 0.3 %.  Use the
+    # exact ``fee_pips`` — ``fee_bps * 100`` would truncate non-100-multiple fees
+    # and address a non-existent PoolKey.
     data_bytes = encode(
         V4_UNLOCK_DATA_TYPES,
         [
             c0,
             c1,
-            hop.fee_bps * 100,
+            hop.fee_pips,
             hop.tick_spacing,
             hop.hooks,
             hop.zero_for_one,
@@ -338,6 +344,9 @@ def _swap_hop_from_route_swap(swap_action: RouteSwap, *, recipient: Address) -> 
         fee_bps=pool.fee_bps,
         recipient=recipient,
         zero_for_one=swap_action.zero_for_one(),
+        # V4 PoolKey fee in pips: prefer the edge's exact lp_fee_pips, falling
+        # back to fee_bps*100 for edges built without slot0 (and for V2/V3).
+        fee_pips=getattr(pool, "lp_fee_pips", 0) or pool.fee_bps * 100,
         tick_spacing=getattr(pool, "tick_spacing", 0),
         hooks=getattr(pool, "hooks", ZERO_ADDRESS),
     )
@@ -413,6 +422,8 @@ def swap_route_to_hops(route: SwapRoute, vm_address: str, recipient: str) -> lis
                 fee_bps=step.fee,
                 recipient=Address(hop_recipient),
                 zero_for_one=zero_for_one,
+                # V4 SwapStep.fee is already the PoolKey fee in pips.
+                fee_pips=step.fee,
                 tick_spacing=getattr(step, "tick_spacing", 0),
                 hooks=getattr(step, "hooks", ZERO_ADDRESS),
             )

--- a/pydefi/vm/swap.py
+++ b/pydefi/vm/swap.py
@@ -26,7 +26,7 @@ from pydefi.abi.amm import (
     UNISWAP_V4_POOL_MANAGER,
     V4_UNLOCK_AMOUNT_OUT_OFFSET,
     V4_UNLOCK_AMOUNT_SPEC_OFFSET,
-    V4_UNLOCK_DATA_TYPES,
+    V4UnlockData,
 )
 from pydefi.pathfinder.dag import RouteDAG, RouteSwap
 from pydefi.types import ZERO_ADDRESS, Address, SwapProtocol, SwapRoute, TokenAmount
@@ -277,28 +277,22 @@ def _build_v4_swap(prog: Program, amount_in: Operand, hop: SwapHop) -> Operand:
     sqrt_price_limit = hop.sqrt_price_limit_x96 or (_SQRT_PRICE_MIN if hop.zero_for_one else _SQRT_PRICE_MAX)
     c0, c1 = _v4_pool_key_currencies(hop)
 
-    # Word layout matches the unlockCallback decoder in DEXCallbackRouter.sol:
-    #   c0(0), c1(1), fee(2), tickSpacing(3), hooks(4),
-    #   zeroForOne(5), amountSpecified(6), sqrtPriceLimitX96(7),
-    #   tokenIn(8), recipient(9)
-    # V4 PoolKey fee is uint24 in pips (1/1_000_000), e.g. 3000 = 0.3 %.  Use the
-    # exact ``fee_pips`` — ``fee_bps * 100`` would truncate non-100-multiple fees
-    # and address a non-existent PoolKey.
-    data_bytes = encode(
-        V4_UNLOCK_DATA_TYPES,
-        [
-            c0,
-            c1,
-            hop.fee_pips,
-            hop.tick_spacing,
-            hop.hooks,
-            hop.zero_for_one,
-            0,
-            sqrt_price_limit,
-            hop.token_in,
-            hop.recipient,
-        ],
-    )
+    # Decoded by the unlockCallback in DEXCallbackRouter.sol.  amountSpecified is
+    # a 0 placeholder, patched at runtime (word 6).  ``fee`` is the exact PoolKey
+    # fee in pips — ``fee_bps * 100`` would truncate non-100-multiple fees and
+    # address a non-existent PoolKey.
+    data_bytes = V4UnlockData(
+        currency0=c0,
+        currency1=c1,
+        fee=hop.fee_pips,
+        tickSpacing=hop.tick_spacing,
+        hooks=hop.hooks,
+        zeroForOne=hop.zero_for_one,
+        amountSpecified=0,
+        sqrtPriceLimitX96=sqrt_price_limit,
+        tokenIn=hop.token_in,
+        recipient=hop.recipient,
+    ).encode()
     calldata = bytes(_V4_PM_UNLOCK_FN(data_bytes).data)
 
     # Patch amountSpecified with -amount_in (two's-complement negation: NOT(x) + 1).

--- a/tests/live/test_defi_vm_fork.py
+++ b/tests/live/test_defi_vm_fork.py
@@ -20,10 +20,12 @@ Run with::
 
 from __future__ import annotations
 
+import dataclasses
 from pathlib import Path
 
 import pytest
 import solcx
+from eth_abi.abi import decode as abi_decode
 from eth_contract.contract import ContractFunction
 from eth_contract.erc20 import ERC20
 from eth_contract.utils import send_transaction as eth_send_transaction
@@ -865,9 +867,7 @@ async def _execute_v4_swap(ctx, token_in: Token, edge: V4PoolEdge, amount_in: in
     ``receive()`` + the ``settle{value}`` path); an ERC-20 is wrapped and sent in.
     """
     w3, vm_address, deployer = ctx["w3"], ctx["vm_address"], ctx["deployer"]
-    swap_tx = build_swap_transaction(
-        RouteDAG().from_token(token_in).swap(USDC, edge), amount_in, vm_address, deployer
-    )
+    swap_tx = build_swap_transaction(RouteDAG().from_token(token_in).swap(USDC, edge), amount_in, vm_address, deployer)
 
     if token_in.address == ZERO_ADDRESS:
         await eth_send_transaction(w3, deployer, to=vm_address, value=Wei(amount_in))
@@ -959,3 +959,26 @@ class TestBuildSwapTransactionFork:
         assert edge.is_token0_in, "native ETH must be currency0 (zeroForOne=true path)"
         received = await _execute_v4_swap(ctx, eth, edge)
         assert received > 0, f"expected USDC out from native ETH V4 swap, got {received}"
+
+    async def test_v4_pool_key_fee_uses_exact_lp_fee(self, ctx) -> None:
+        """The V4 PoolKey fee must be the pool's exact lp_fee_pips, not the
+        truncated fee_bps*100 — which derives a non-existent poolId and reverts
+        for fees that are not a multiple of 100 pips.
+        """
+        edge = await _v4_pool_edge_or_skip(ctx["w3"], WETH)
+
+        def program_of(e: V4PoolEdge) -> bytes:
+            dag = RouteDAG().from_token(e.token_in).swap(e.token_out, e)
+            tx = build_swap_transaction(dag, 10**16, ctx["vm_address"], ctx["deployer"])
+            (program,) = abi_decode(["bytes"], tx.data[4:])
+            return program
+
+        # The real pool's exact on-chain fee is embedded in compiled program.
+        assert edge.lp_fee_pips.to_bytes(32, "big") in program_of(edge)
+
+        # Clone same pool with a non-100-multiple fee: exact value must be encoded.
+        odd = edge.lp_fee_pips + 50
+        odd_edge = dataclasses.replace(edge, lp_fee_pips=odd, fee_bps=odd // 100)
+        program = program_of(odd_edge)
+        assert odd.to_bytes(32, "big") in program
+        assert (odd_edge.fee_bps * 100).to_bytes(32, "big") not in program

--- a/tests/live/test_defi_vm_fork.py
+++ b/tests/live/test_defi_vm_fork.py
@@ -33,12 +33,21 @@ from web3.exceptions import ContractLogicError, Web3RPCError
 from web3.types import Wei
 
 from pydefi.abi.amm import UNISWAP_V3_POOL
-from pydefi.pathfinder.graph import PoolGraph, V3PoolEdge
+from pydefi.amm.uniswap_v4 import UniswapV4
+from pydefi.exceptions import InsufficientLiquidityError
+from pydefi.pathfinder.dag import RouteDAG
+from pydefi.pathfinder.graph import PoolGraph, V3PoolEdge, V4PoolEdge
 from pydefi.pathfinder.router import Router, _dag_leg_weights
-from pydefi.types import Address, TokenAmount
+from pydefi.types import ZERO_ADDRESS, Address, Token, TokenAmount
 from pydefi.vm import Program
 from pydefi.vm.swap import build_swap_transaction
-from tests.addrs import POOL_WETH_USDC_500, POOL_WETH_USDC_3000
+from tests.addrs import (
+    POOL_WETH_USDC_500,
+    POOL_WETH_USDC_3000,
+    UNISWAP_V4_POOL_MANAGER,
+    UNISWAP_V4_QUOTER,
+    UNISWAP_V4_STATE_VIEW,
+)
 from tests.live.sol_utils import (
     MOCK_TOKEN_SOL,
     compile_sol_file,
@@ -829,6 +838,48 @@ async def _v3_pool_edge(w3, pool_address: Address, token_in, token_out) -> V3Poo
 
 _WETH_DEPOSIT = ContractFunction.from_abi("function deposit() external payable")
 
+# V4 fee tiers probed in order of popularity: 0.05% / 0.3% / 0.01% / 1%.
+_V4_FEE_TIERS = ((500, 10), (3000, 60), (100, 1), (10000, 200))
+
+
+async def _v4_pool_edge_or_skip(w3, token_in: Token, tiers=_V4_FEE_TIERS) -> V4PoolEdge:
+    """Return the first initialised *token_in*->USDC V4 pool edge, or skip."""
+    v4 = UniswapV4(
+        w3=w3,
+        pool_manager_address=UNISWAP_V4_POOL_MANAGER,
+        state_view_address=UNISWAP_V4_STATE_VIEW,
+        quoter_address=UNISWAP_V4_QUOTER,
+    )
+    for fee, tick in tiers:
+        try:
+            return await v4.get_pool_edge(token_in, USDC, fee=fee, tick_spacing=tick)
+        except InsufficientLiquidityError:
+            continue
+    pytest.skip(f"no initialised {token_in.symbol}/USDC V4 pool on this fork")
+
+
+async def _execute_v4_swap(ctx, token_in: Token, edge: V4PoolEdge, amount_in: int = 10**16) -> int:
+    """Fund the VM, broadcast a *token_in*->USDC V4 swap, and return the USDC delta.
+
+    Native ETH (``address(0)``) is pre-funded with a bare transfer (exercising
+    ``receive()`` + the ``settle{value}`` path); an ERC-20 is wrapped and sent in.
+    """
+    w3, vm_address, deployer = ctx["w3"], ctx["vm_address"], ctx["deployer"]
+    swap_tx = build_swap_transaction(
+        RouteDAG().from_token(token_in).swap(USDC, edge), amount_in, vm_address, deployer
+    )
+
+    if token_in.address == ZERO_ADDRESS:
+        await eth_send_transaction(w3, deployer, to=vm_address, value=Wei(amount_in))
+    else:
+        await _WETH_DEPOSIT().transact(w3, deployer, to=token_in.address, value=Wei(amount_in))
+        await ERC20.fns.transfer(vm_address, amount_in).transact(w3, deployer, to=token_in.address)
+
+    bal_before = await ERC20.fns.balanceOf(deployer).call(w3, to=USDC.address)
+    await eth_send_transaction(w3, deployer, to=swap_tx.to, data=swap_tx.data)
+    bal_after = await ERC20.fns.balanceOf(deployer).call(w3, to=USDC.address)
+    return bal_after - bal_before
+
 
 @pytest.mark.fork
 class TestBuildSwapTransactionFork:
@@ -884,3 +935,27 @@ class TestBuildSwapTransactionFork:
         bal_after = await ERC20.fns.balanceOf(deployer).call(w3, to=USDC.address)
 
         assert bal_after > bal_before, f"Expected USDC > 0 after split swap, got {bal_after - bal_before}"
+
+    async def test_v4_swap_build_and_execute(self, ctx) -> None:
+        """WETH->USDC V4 swap via DeFiVM's ``unlockCallback``.
+
+        The VM calls ``PoolManager.unlock()``; the callback performs the swap,
+        settles WETH from the VM's balance (sync→transfer→settle), and ``take``s
+        USDC to the deployer.
+        """
+        edge = await _v4_pool_edge_or_skip(ctx["w3"], WETH)
+        received = await _execute_v4_swap(ctx, WETH, edge)
+        assert received > 0, f"expected USDC out from V4 swap, got {received}"
+
+    async def test_v4_native_eth_swap_build_and_execute(self, ctx) -> None:
+        """Native ETH->USDC V4 swap: exercises the ``settle{value}`` branch.
+
+        Native ETH is ``address(0)`` (currency0), driving ``zeroForOne=true`` and
+        the native-settle path the WETH test does not; the bare ETH pre-fund also
+        exercises ``receive()``.
+        """
+        eth = Token(chain_id=1, address=ZERO_ADDRESS, symbol="ETH", decimals=18)
+        edge = await _v4_pool_edge_or_skip(ctx["w3"], eth)
+        assert edge.is_token0_in, "native ETH must be currency0 (zeroForOne=true path)"
+        received = await _execute_v4_swap(ctx, eth, edge)
+        assert received > 0, f"expected USDC out from native ETH V4 swap, got {received}"


### PR DESCRIPTION
Allow V4 execution via `unlockCallback`. V4 swap runs inside `PoolManager.unlock(data)`: the manager calls the unlocker back, and the swap + settlement must happen in that callback. `DEXCallbackRouter` (inherited by DeFiVM and every composer) now implements `unlockCallback(bytes)` — it decodes the 10-word unlock payload, calls `PoolManager.swap`, settles the input debt (`sync`→`transfer`→`settle`, or `settle{value}` for native ETH), and `take`s the output to the recipient. `_build_route_swap` compiles V4 hops to `PoolManager.unlock`, so `build_swap_transaction` executes V4 `RouteDAG`s end to end.